### PR TITLE
CP-28767: Move systemd/coredump log from /var/lib to /var/log

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -990,7 +990,7 @@ exclude those logs from the archive.
 
     tree_output(CAP_XENRT, '/tmp', FIST_RE)
 
-    file_output(CAP_XENRT, ['/var/lib/systemd/coredump/*'])
+    file_output(CAP_XENRT, ['/var/log/systemd/coredump/*'])
     tree_output(CAP_XENRT, '/tmp', re.compile(r'^.*xen\.qemu-dm\.'))
 
     file_output(CAP_XENSERVER_CONFIG, [INITIAL_INVENTORY])


### PR DESCRIPTION
This accompanies a Systemd change