### PR TITLE
CP-45506: Verify that /etc/systemd does not have files(moved to tarball)

### DIFF
--- a/tests/integration/dom0-template/etc/systemd/system.conf
+++ b/tests/integration/dom0-template/etc/systemd/system.conf
@@ -1,0 +1,60 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See systemd-system.conf(5) for details.
+
+[Manager]
+#LogLevel=info
+#LogTarget=journal-or-kmsg
+#LogColor=yes
+#LogLocation=no
+#DumpCore=yes
+#CrashShell=no
+#ShowStatus=yes
+#CrashChVT=1
+#CtrlAltDelBurstAction=reboot-force
+#CPUAffinity=1 2
+#JoinControllers=cpu,cpuacct net_cls,net_prio
+#RuntimeWatchdogSec=0
+#ShutdownWatchdogSec=10min
+#CapabilityBoundingSet=
+#SystemCallArchitectures=
+#TimerSlackNSec=
+#DefaultTimerAccuracySec=1min
+#DefaultStandardOutput=journal
+#DefaultStandardError=inherit
+#DefaultTimeoutStartSec=90s
+#DefaultTimeoutStopSec=90s
+#DefaultRestartSec=100ms
+#DefaultStartLimitInterval=10s
+#DefaultStartLimitBurst=5
+#DefaultEnvironment=
+#DefaultCPUAccounting=no
+#DefaultBlockIOAccounting=no
+#DefaultMemoryAccounting=no
+#DefaultTasksAccounting=no
+#DefaultTasksMax=
+#DefaultLimitCPU=
+#DefaultLimitFSIZE=
+#DefaultLimitDATA=
+#DefaultLimitSTACK=
+#DefaultLimitCORE=
+#DefaultLimitRSS=
+#DefaultLimitNOFILE=
+#DefaultLimitAS=
+#DefaultLimitNPROC=
+#DefaultLimitMEMLOCK=
+#DefaultLimitLOCKS=
+#DefaultLimitSIGPENDING=
+#DefaultLimitMSGQUEUE=
+#DefaultLimitNICE=
+#DefaultLimitRTPRIO=
+#DefaultLimitRTTIME=


### PR DESCRIPTION
Add the trivial remaining verification that /etc/systemd is indeed _**moved as required by CP-45506**_ to the tarball (the tarball is already checked, but also no files in /etc/systemd/ may remain there, everything must be in the tarball).