### PR TITLE
CP-41819: Start py3 migration with config for isort and apply isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,62 @@
+[project]
+# https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+name = "xenserver-status-report"
+dynamic = ["version"]
+description = "Xenserver Status Report"
+requires-python = "2.7"
+license = "LGPL-2.1-only"
+keywords = ["xenserver", "xen-project"]
+authors = [
+    {name = "Ewan Mellor"},
+    {name = "Simon Rowe"},
+]
+maintainers = [
+    {name = "Ashwin H"},
+    {name = "Bernhard Kaindl"},
+    {name = "Pau Ruiz Safont"},
+    {name = "Ross Lagerwall"},
+]
+readme = "README.md"
+classifiers = [
+    "Environment :: Console",
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
+    "Operating System :: POSIX :: Linux :: XenServer/XCP-ng Dom0",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: System :: Logging",
+    "Topic :: System :: Monitoring",
+]
+dependencies = [
+    "defusedxml",
+    "six",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest<7",
+]
+
+[project.urls]
+homepage = "https://github.com/xenserver/status-report/"
+repository = "https://github.com/xenserver/status-report/"
+
+[build-system]
+requires = ["setuptools>=42", "setuptools_scm[toml]"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# This section is needed (can be empty) for setuptools_scm to be used by
+# "pip2 install ." in order to get the version number from the git repo.
+
+[tool.black]
+line-length = 100
+
+[tool.isort]
+line_length = 100
+py_version = 27
+profile = "black"
+combine_as_imports = true
+ensure_newline_before_comments = false
+# extra standard libraries of Py2:
+extra_standard_library = "commands"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+# Minimum setup.cfg needed for "python2 -m pip install ." to get the name:
+[metadata]
+name = xenserver-status-report

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -33,32 +33,33 @@
 # or func_output().
 #
 
+import commands
+import fcntl
 import getopt
+import glob
 import io
-import re
+import json
 import os
+import platform
+import pprint
+import re
+import socket
 import StringIO
 import sys
 import tarfile
 import time
-import commands
-import pprint
-from xml.dom.minidom import parse, getDOMImplementation
-import zipfile
-from subprocess import Popen, PIPE
-from select import select
-from signal import SIGTERM, SIGUSR1, SIGHUP
-import platform
-import fcntl
-import glob
-import urllib
-import socket
 import traceback
-import json
-import defusedxml.sax
+import urllib
 import xml
+import zipfile
+from select import select
+from signal import SIGHUP, SIGTERM, SIGUSR1
+from subprocess import PIPE, Popen
+from xml.dom.minidom import getDOMImplementation, parse
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
+
+import defusedxml.sax
 
 try:
     import hashlib
@@ -81,7 +82,7 @@ def exceptionless_del(*argl, **kwargs):
 zipfile.ZipFile.__del__ = exceptionless_del
 
 def xapi_local_session():
-    import XenAPI # Import on first use.
+    import XenAPI  # Import on first use.
     return XenAPI.xapi_local()
 
 OS_RELEASE = platform.release()
@@ -1858,7 +1859,7 @@ def construct_filename(subdir, k, v):
 
 
 def update_capabilities():
-    from xen.lowlevel.xc import xc, Error as xcError # Import on first use.
+    from xen.lowlevel.xc import Error as xcError, xc  # Import on first use.
 
     update_cap_size(CAP_HOST_CRASHDUMP_LOGS,
                     size_of_dir(HOST_CRASHDUMPS_DIR, HOST_CRASHDUMP_LOGS_EXCLUDES_RE, True))


### PR DESCRIPTION
This the the 1st PR to migrate to Python3:

Start off with a defined config and as most imports will have to be updated,
support the imports to be placed using `isort` at the expected place.
 
Changes:
- Add .pyproject.toml with configuration for isort and line length
- Add setup.cfg, enable `pip install .` with setuptools_scm
- Apply an initial isort to prepare upcoming imports using isort.
