### PR TITLE
CP-41819: Update except and print() syntax to Python3, use logging

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -41,6 +41,7 @@ import getopt
 import glob
 import io
 import json
+import logging
 import os
 import platform
 import pprint
@@ -649,8 +650,8 @@ def main(argv = None):
                             'output=', 'outfd=', 'all', 'unlimited', 'debug',
                             'help'])
     except getopt.GetoptError as opterr:
-        print(opterr, file=sys.stderr)
-        print(usage(), file=sys.stderr)
+        logging.fatal("xen-bugtool: %s", opterr)
+        logging.fatal(usage())
         return 2
 
     for (k, v) in options:
@@ -660,7 +661,7 @@ def main(argv = None):
 
     # we need access to privileged files, exit if we are not running as root
     if os.getuid() != 0:
-        print("Error: xen-bugtool must be run as root", file=sys.stderr)
+        logging.fatal("Error: xen-bugtool must be run as root")
         return 1
 
     try:
@@ -696,7 +697,7 @@ def main(argv = None):
             if  v in ['tar', 'tar.bz2', 'zip']:
                 output_type = v
             else:
-                print("Invalid output format '%s'" % v, file=sys.stderr)
+                logging.fatal("Invalid output format '%s'", v)
                 return 2
 
         # "-s" or "--silent" means suppress output (except for the final
@@ -725,7 +726,7 @@ def main(argv = None):
                 old = fcntl.fcntl(output_fd, fcntl.F_GETFD)
                 fcntl.fcntl(output_fd, fcntl.F_SETFD, old | fcntl.FD_CLOEXEC)
             except:
-                print("Invalid output file descriptor", output_fd, file=sys.stderr)
+                logging.fatal("Invalid output file descriptor: %d", output_fd)
                 return 2
 
         elif k in ['-a', '--all']:
@@ -738,11 +739,11 @@ def main(argv = None):
             ProcOutput.debug = True
 
     if len(params) != 1:
-        print("Invalid additional arguments", str(params), file=sys.stderr)
+        logging.fatal("Invalid additional arguments: %s", str(params))
         return 2
 
     if output_fd != -1 and output_type != 'tar':
-        print("Option '--outfd' only valid with '--output=tar'", file=sys.stderr)
+        logging.fatal("Option '--outfd' only valid with '--output=tar'")
         return 2
 
     if ANSWER_YES_TO_ALL:
@@ -2182,6 +2183,7 @@ class StringIOmtime(StringIO.StringIO):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(format="%(message)s")
     try:
         sys.exit(main())
     except KeyboardInterrupt:

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -737,6 +737,7 @@ def main(argv = None):
         elif k in ['-d', '--debug']:
             dbg = True
             ProcOutput.debug = True
+            logging.getLogger().setLevel(logging.DEBUG)  # Activates logging.debug("log messages")
 
     if len(params) != 1:
         logging.fatal("Invalid additional arguments: %s", str(params))
@@ -1182,10 +1183,9 @@ exclude those logs from the archive.
     except:
         pass
 
-    if dbg:
-        print("Category sizes (max, actual):\n", file=sys.stderr)
-        for c in caps.keys():
-            print("    %s (%d, %d)" % (c, caps[c][MAX_SIZE], cap_sizes[c]), file=sys.stderr)
+    logging.debug("Category sizes (max, actual):\n")
+    for c in caps.keys():
+        logging.debug("    %s (%d, %d)", c, caps[c][MAX_SIZE], cap_sizes[c])
     return res
 
 def find_tapdisk_logs():

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -646,7 +646,7 @@ def main(argv = None):
             argv, 'adsuy', ['capabilities', 'silent', 'yestoall', 'entries=',
                             'output=', 'outfd=', 'all', 'unlimited', 'debug',
                             'help'])
-    except getopt.GetoptError, opterr:
+    except getopt.GetoptError as opterr:
         print >>sys.stderr, opterr
         print >>sys.stderr, usage()
         return 2
@@ -1743,7 +1743,7 @@ class TarOutput(ArchiveWithTarSubarchives):
                 if SILENT_MODE:
                     print self.filename
             return True
-        except Exception, e:
+        except Exception as e:
             if self.output_fd == -1:
                 output ("Error closing tar file '%s': '%s'" % (self.filename, e))
             else:
@@ -1782,7 +1782,7 @@ class ZipOutput(ArchiveWithTarSubarchives):
             if SILENT_MODE:
                 print self.filename
             return True
-        except Exception, e:
+        except Exception as e:
             output ("Error closing zip file '%s': %s" % (self.filename, e))
             output ("Cleaning up incomplete file '%s'" % self.filename)
             removeNoError(self.filename)

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -476,11 +476,11 @@ def log(x, print_output=True):
         output(x)
 
     with open(XEN_BUGTOOL_LOG, "a") as logFile:
-        print >>logFile, x
+        print(x, file=logFile)
 
 def output(x):
     if not SILENT_MODE:
-        print x
+        print(x)
 
 def output_ts(x):
     output("[%s]  %s" % (time.strftime("%x %X %Z"), x))
@@ -653,7 +653,7 @@ def main(argv = None):
 
     for (k, v) in options:
         if k == '--help':
-            print usage()
+            print(usage())
             return 0
 
     # we need access to privileged files, exit if we are not running as root
@@ -1741,7 +1741,7 @@ class TarOutput(ArchiveWithTarSubarchives):
             if self.output_fd == -1:
                 output ('Writing tarball %s successful.' % self.filename)
                 if SILENT_MODE:
-                    print self.filename
+                    print(self.filename)
             return True
         except Exception as e:
             if self.output_fd == -1:
@@ -1780,7 +1780,7 @@ class ZipOutput(ArchiveWithTarSubarchives):
             self.zf.close()
             output ('Writing archive %s successful.' % self.filename)
             if SILENT_MODE:
-                print self.filename
+                print(self.filename)
             return True
         except Exception as e:
             output ("Error closing zip file '%s': %s" % (self.filename, e))
@@ -1941,7 +1941,7 @@ def print_capabilities():
     document = getDOMImplementation().createDocument(
         "ns", CAP_XML_ROOT, None)
     map(lambda key: capability(document, key), [k for k in caps.keys() if not caps[k][HIDDEN]])
-    print document.toprettyxml()
+    print(document.toprettyxml())
 
 def capability(document, key):
     c = caps[key]
@@ -2184,5 +2184,5 @@ if __name__ == "__main__":
     try:
         sys.exit(main())
     except KeyboardInterrupt:
-        print "\nInterrupted."
+        print("\nInterrupted.")
         sys.exit(3)

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -33,6 +33,8 @@
 # or func_output().
 #
 
+from __future__ import print_function
+
 import commands
 import fcntl
 import getopt
@@ -647,8 +649,8 @@ def main(argv = None):
                             'output=', 'outfd=', 'all', 'unlimited', 'debug',
                             'help'])
     except getopt.GetoptError as opterr:
-        print >>sys.stderr, opterr
-        print >>sys.stderr, usage()
+        print(opterr, file=sys.stderr)
+        print(usage(), file=sys.stderr)
         return 2
 
     for (k, v) in options:
@@ -658,7 +660,7 @@ def main(argv = None):
 
     # we need access to privileged files, exit if we are not running as root
     if os.getuid() != 0:
-        print >>sys.stderr, "Error: xen-bugtool must be run as root"
+        print("Error: xen-bugtool must be run as root", file=sys.stderr)
         return 1
 
     try:
@@ -694,7 +696,7 @@ def main(argv = None):
             if  v in ['tar', 'tar.bz2', 'zip']:
                 output_type = v
             else:
-                print >>sys.stderr, "Invalid output format '%s'" % v
+                print("Invalid output format '%s'" % v, file=sys.stderr)
                 return 2
 
         # "-s" or "--silent" means suppress output (except for the final
@@ -723,7 +725,7 @@ def main(argv = None):
                 old = fcntl.fcntl(output_fd, fcntl.F_GETFD)
                 fcntl.fcntl(output_fd, fcntl.F_SETFD, old | fcntl.FD_CLOEXEC)
             except:
-                print >>sys.stderr, "Invalid output file descriptor", output_fd
+                print("Invalid output file descriptor", output_fd, file=sys.stderr)
                 return 2
 
         elif k in ['-a', '--all']:
@@ -736,11 +738,11 @@ def main(argv = None):
             ProcOutput.debug = True
 
     if len(params) != 1:
-        print >>sys.stderr, "Invalid additional arguments", str(params)
+        print("Invalid additional arguments", str(params), file=sys.stderr)
         return 2
 
     if output_fd != -1 and output_type != 'tar':
-        print >>sys.stderr, "Option '--outfd' only valid with '--output=tar'"
+        print("Option '--outfd' only valid with '--output=tar'", file=sys.stderr)
         return 2
 
     if ANSWER_YES_TO_ALL:
@@ -1180,10 +1182,9 @@ exclude those logs from the archive.
         pass
 
     if dbg:
-        print >>sys.stderr, "Category sizes (max, actual):\n"
+        print("Category sizes (max, actual):\n", file=sys.stderr)
         for c in caps.keys():
-            print >>sys.stderr, "    %s (%d, %d)" % (c, caps[c][MAX_SIZE],
-                                                     cap_sizes[c])
+            print("    %s (%d, %d)" % (c, caps[c][MAX_SIZE], cap_sizes[c]), file=sys.stderr)
     return res
 
 def find_tapdisk_logs():


### PR DESCRIPTION
TLDR: I expect a review of this PR to take maybe 2-3 minutes or so, it's really short and easy:

The only change that is only obvious by reviewing each commit by commit is this change:
```py
    if k in ['-d', '--debug']:
       dbg = True
+      logging.getLogger().setLevel(logging.DEBUG)  # Activates logging.debug("log messages")
...
From:
-   if dbg:
-      print(...., file=sys.stderr)
-      for (...):
-          print(...., file=sys.stderr)
To:
+   debug(....)
+   for (...):
+       debug(....)   # (Logging default to stderr)
```
It should be clear - if not preferred, I can remove the last one or two commits.
<hr>
2nd Pull request for the Python3 migration of xenserver-status-report:
- Updates the except and print() syntax to support Python3
- Updates the prints to `stderr` to use `logging` or more readable code.

It is split into 5 incremental commits with each commit making one dedicated step of the updates:
```py
git log -n5 --oneline |tac
e11a306 CP-41819: Update except syntax (apply 2to3 -f except)
fc0f829 CP-41819: Update print syntax: Apply 2to3 -f print (Part 1)
03f9ec7 CP-41819: Update print syntax: Apply 2to3 -f print (Part 2: stderr)
c2954e2 CP-41819: Convert print(..., file=sys.stderr) before exit()s to logging.fatal()
3827179 CP-41819: Convert debugging print(...)s to debug(...)
```
I tested the uses of logging to work as expected and `pylint` (in GitHub CI) ensured that I fixed any logging argument errors (logging functions need format strings) that I had initially made.

The combined change is small, and can easily reviewed at once (or commit by commit).