### PR TITLE
Use hashlib.md5 and skip monkeypatching ZipFile for 3.7+

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -65,16 +65,18 @@ from xml.etree.ElementTree import Element
 
 import defusedxml.sax
 
+# Fixed in 3.7: https://github.com/python/cpython/pull/12628
 # Monkey-patch zipfile's __del__ function to be less stupid
 #   Specifically, it calls close which further writes to the file, which
 #   fails with ENOSPC if the root filesystem is full
-zipfile_del = zipfile.ZipFile.__del__
-def exceptionless_del(*argl, **kwargs):
-    try:
-        zipfile_del(*argl, **kwargs)
-    except:
-        pass
-zipfile.ZipFile.__del__ = exceptionless_del
+if sys.version < "3.7":
+    zipfile_del = zipfile.ZipFile.__del__  # type: ignore[attr-defined] # mypy,pyright
+    def exceptionless_del(*argl, **kwargs):
+        try:
+            zipfile_del(*argl, **kwargs)
+        except OSError:
+            pass
+    zipfile.ZipFile.__del__ = exceptionless_del  # type: ignore[attr-defined] # mypy,pyright
 
 def xapi_local_session():
     import XenAPI  # Import on first use.

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -55,6 +55,7 @@ import traceback
 import urllib
 import xml
 import zipfile
+from hashlib import md5 as md5_new
 from select import select
 from signal import SIGHUP, SIGTERM, SIGUSR1
 from subprocess import PIPE, Popen
@@ -63,15 +64,6 @@ from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
 import defusedxml.sax
-
-try:
-    import hashlib
-    def md5_new():
-        return hashlib.md5()
-except:
-    import md5
-    def md5_new():
-        return md5.new()
 
 # Monkey-patch zipfile's __del__ function to be less stupid
 #   Specifically, it calls close which further writes to the file, which


### PR DESCRIPTION
Two short and trivial updates for Python 3.x (to get these out of the way):

1. [Use hashlib.md5 (2.7 and py3) as md5_new()](https://github.com/xenserver/status-report/commit/c53c2aaea781ae7d8081d52c46683495c19ccbb3)
2. [Skip monkey-patching ZipFile on py3.7+ (has the fix)](https://github.com/xenserver/status-report/commit/00ff7a992b2761e26629cbdc685dfb25242925d6)
   - With link to the fix PR for reference:
     - https://github.com/python/cpython/pull/12628