### PR TITLE
xen-bugtool/make_inventory(): Py3: Update tuple lambda to for loop

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1806,8 +1806,8 @@ def make_inventory(inventory, subdir):
     s.setAttribute('uptime', commands.getoutput(UPTIME))
     document.getElementsByTagName(INVENTORY_XML_ROOT)[0].appendChild(s)
 
-    map(lambda (k, v): inventory_entry(document, subdir, k, v),
-        inventory.items())
+    for inventory_key, inventory_item in inventory.items():
+        inventory_entry(document, subdir, inventory_key, inventory_item)
     return document.toprettyxml()
 
 def inventory_entry(document, subdir, k, v):


### PR DESCRIPTION
Update a `map()` in `make_inventory()` to also work with Python3 (using a for loop - more readable and concise):

The syntax for `tuple` parameters in `lambda` functions has been removed in Python3 and must be replaced:
<hr>
This code iterates over the inventory dictionary using the items() method and unpacks each key-value pair into k and v. Then, it calls the inventory_entry() function with the appropriate arguments.

In general, map() is useful when you want to apply a function to every item of an iterable and return a list of the results.

However, if you only need to iterate over the items of an iterable and perform some operation on each item, a for loop is often more readable and concise than using map().
<hr>

Established for Python3 migration with a recent Python3 merge for xsconsole:

Replacing such map() loops with a for loop has already been established with the recently merged equivalent Python3 commit for xsconsole.

CI Tests of this code:

The functionality of this code is already tested by each of the test cases in tests/integration/ as all of them validate the contents and XML schema of bugtool-output/inventory.xml