### PR TITLE
Add system load testcase to check collecting sar output, improve verification code

### DIFF
--- a/tests/integration/test_system_load.py
+++ b/tests/integration/test_system_load.py
@@ -1,0 +1,31 @@
+"""tests/integration/test_system_load.py: Test xen-bugtool --entries=system-load"""
+import os
+
+from utils import check_file, run_bugtool_entry, assert_content_from_dom0_template
+
+
+# In this test case we need to sleep for 1 sec, and it is sufficient
+# to test to only with zip archives to keep the test duration short:
+def test_system_load(output_archive_type="zip"):
+    """Test xen-bugtool --entries=system-load in test jail created by auto-fixtures in conftest.py"""
+    entry = "system-load"
+
+    # Create test input files:
+    os.mkdir("/var/log")
+    os.mkdir("/var/log/sa")
+    with open("/var/log/sa/sa01", "w") as sa01:
+        sa01.write("sa01 test data")
+    with open("/var/log/sa/sar31", "w") as sar31:
+        sar31.write("sar31 test data")
+
+    # Create a dummy sar script to assert that xen-bugtool captures its output:
+    os.environ["PATH"] = "/var:" + os.environ["PATH"]
+    with open("/var/sar", "w") as sar:
+        sar.write("#!/bin/sh\nsleep 1;cat /etc/xensource-inventory\n")
+    os.chmod("/var/sar", 0o777)
+
+    run_bugtool_entry(output_archive_type, entry)
+
+    assert_content_from_dom0_template("sar-A.out", "etc/xensource-inventory")
+    assert check_file("var/log/sa/sa01") == "sa01 test data"
+    assert check_file("var/log/sa/sar31") == "sar31 test data"

--- a/tests/integration/test_xenserver_config.py
+++ b/tests/integration/test_xenserver_config.py
@@ -1,7 +1,7 @@
 """tests/integration/test_xenserver_config.py: Test xen-bugtool --entries=xenserver-config"""
 import os
 
-from utils import assert_cmd, check_file, run_bugtool_entry, verify_content_from_dom0_template
+from utils import assert_cmd, check_file, run_bugtool_entry, assert_content_from_dom0_template
 
 
 def test_xenserver_config(output_archive_type):
@@ -14,5 +14,5 @@ def test_xenserver_config(output_archive_type):
     os.chdir("..")
     assert_cmd(["tar", "xvf", entry + "/etc/systemd.tar"], entry + "/etc/systemd.tar")
     os.chdir(entry)
-    verify_content_from_dom0_template("etc/xensource-inventory")
-    verify_content_from_dom0_template("etc/systemd")
+    assert_content_from_dom0_template("etc/systemd")
+    assert_content_from_dom0_template("etc/xensource-inventory")

--- a/tests/integration/test_xenserver_config.py
+++ b/tests/integration/test_xenserver_config.py
@@ -7,12 +7,19 @@ from utils import assert_cmd, check_file, run_bugtool_entry, assert_content_from
 def test_xenserver_config(output_archive_type):
     """Test xen-bugtool --entries=xenserver-config in test jail created by auto-fixtures in conftest.py"""
     entry = "xenserver-config"
+
     run_bugtool_entry(output_archive_type, entry)
+
+    # Assert that the bugtool output archive of --entries=xenserver-config matches our expectations for it:
     assert check_file("ls-lR-%opt%xensource.out").splitlines()[0] == "/opt/xensource:"
     assert check_file("ls-lR-%etc%xensource%static-vdis.out") == ""
     assert check_file("static-vdis-list.out") == "list"
+
+    # Assert the contents of the extracted etc/systemd.tar
     os.chdir("..")
+    # etc/systemd.tar's toplevel directory is os.environ["XENRT_BUGTOOL_BASENAME"] (= entries for the test)
     assert_cmd(["tar", "xvf", entry + "/etc/systemd.tar"], entry + "/etc/systemd.tar")
+
     os.chdir(entry)
     assert_content_from_dom0_template("etc/systemd")
     assert_content_from_dom0_template("etc/xensource-inventory")

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -49,7 +49,7 @@ def check_file(path):
     return contents
 
 
-def verify_content_from_dom0_template(path, control_path=None):
+def assert_content_from_dom0_template(path, control_path=None):
     """Compare the contents of output directories or files with the test's Dom0 template directories"""
     assert path[0] != "/"
     control = BUGTOOL_DOM0_TEMPL + (control_path or path)


### PR DESCRIPTION
Improve integration tests:

Three small commits with to improve verifying the bugtool output and add a testcase:

1. [Improve verifying the expected bugtool output with the dom0 template files](https://github.com/xenserver/status-report/commit/e687eaad7ced3b82bf79a1b7d768ce2d72fe1893)

2. [integration/utils.py: rename function to assert_... like assert_cmd()](https://github.com/xenserver/status-report/commit/723218e34ab63647a976776a8911b49fdbe938a8)

3. [Add tests/integration/test_system_load.py to assert sar output](https://github.com/xenserver/status-report/commit/61b87bcab4baffc2378573e8b8c63c606c59249c)