### PR TITLE
tests/unit/conftest.py: Add a common pytest fixture to test functions of xen-bugtool

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,40 @@
+"""tests/unit/conftest.py: pytest fixtures for unit-testing functions in the xen-bugtool script"""
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def testdir():
+    """Test fixture to get the directory of the unit test for finding other files relative to it"""
+    return os.path.dirname(__file__)
+
+
+@pytest.fixture(scope="session")
+def bugtool(testdir):
+    """Test fixture to import the xen-bugtool script as a module for executing unit tests on functions"""
+
+    # This uses the deprecated imp module because it needs also to run with Python2.7 for now:
+    def import_from_file(module_name, file_path):
+        import sys
+
+        if sys.version_info.major == 2:
+            import imp  # pylint: disable=deprecated-module  # pyright: ignore[reportMissingImports]
+
+            return imp.load_source(module_name, file_path)
+        else:
+            # Py3.11+: Importing Python source code from a script without the .py extension:
+            # https://gist.github.com/bernhardkaindl/1aaa04ea925fdc36c40d031491957fd3:
+            from importlib import machinery, util
+
+            loader = machinery.SourceFileLoader(module_name, file_path)
+            spec = util.spec_from_loader(module_name, loader)
+            assert spec
+            assert spec.loader
+            module = util.module_from_spec(spec)
+            # Probably a good idea to add manually imported module stored in sys.modules
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+            return module
+
+    return import_from_file("bugtool", testdir + "/../../xen-bugtool")

--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -56,10 +56,8 @@ expected = r"""<?xml version="1.0" ?>
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 0), reason="requires python2")
-def test_xapi_database_filter():
+def test_xapi_database_filter(bugtool):
     """Assert that bugtool.DBFilter().output() filters the xAPI database as expected"""
-    import imp  # pylint: disable=deprecated-module  # pyright: ignore[reportMissingImports]
 
-    bugtool = imp.load_source("bugtool", testdir + "/../../xen-bugtool")
     filtered = bugtool.DBFilter(original).output()
     assert xml.dom.minidom.parseString(filtered).toprettyxml(indent="    ") == expected


### PR DESCRIPTION
Summary for @GeraldEV (or other reviewers): This PR:

- It moves existing code to make it commonly usable.
- It adds support for executing the tests with the newer Python3 builds provided in GitHub actions
- It is tested in GitHub CI

### Details

Converts the existing `pytest` fixture to test functions of `xen-bugtool` to a common pytest fixtures:
- Moves the `bugtool` test fixture from the existing test case into `pytest`'s `conftest.py` to make it available for all unit tests which need to test `bugtool` functions for updating them to support Python3.
- To support using the test fixture with newer Python versions, add modern import loader using `importlib`.

### Outlook of it's use, just as information beforehand:

The Python3 migration of `xen-bugtool` is really tricky (PRs will be documented, details then for each one):

This test fixture will be used by many unit tests to test `bugtool` functions before and after adding Python3 support to ensure that the changes do not harm (change behavior) of the code in any way!

This will be done in a test-driven manner (Test-Driven Development):
1. To ensure that the test case is correct for the behavior of the existing code,
   tests running on Python2 (in GitHub CI) will be added with an initial commit!
2. Python3 changes will be applied, without any change to the test case except for opening it's execution on Python3 to enable testing. Again, with verification using GitHub CI.

All commits should show a green checkmark symbol.