### PR TITLE
tests/unit/test_xapidb_filter.py: Update/Prepare testcase for Python3

### DIFF
--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -70,7 +70,6 @@ def assert_xml_element_trees_equiv(a, b):
     # Recursively repeat for all child nodes (expect same order of child nodes):
     for achild, bchild in zip(list(a), list(b)):
         assert assert_xml_element_trees_equiv(achild, bchild)
-    return True
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 0), reason="requires python2")

--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -1,8 +1,8 @@
 """tests/unit/test_xapidb_filter.py: Ensure that the xen-bugtool.DBFilter() filters the XAPI DB properly"""
-# This uses the deprecated imp module because it has to run with Python2.7 for now:
 import os
 import sys
 import xml.dom.minidom
+import xml.etree.ElementTree as ET
 
 import pytest
 
@@ -55,9 +55,34 @@ expected = r"""<?xml version="1.0" ?>
 """
 
 
+def assert_xml_element_trees_equiv(a, b):
+    """Assert that the contents of two XML ElementTrees are equivalent (recursive)"""
+    # Check the XML tag
+    assert a.tag == b.tag
+    # Check the XML text
+    assert (a.text or "").strip() == (b.text or "").strip()
+    # Check the XML tail
+    assert (a.tail or "").strip() == (b.tail or "").strip()
+    # Check the XML attributes
+    assert a.attrib.items() == b.attrib.items()
+    # Compare the number of child nodes
+    assert len(list(a)) == len(list(b))
+    # Recursively repeat for all child nodes (expect same order of child nodes):
+    for achild, bchild in zip(list(a), list(b)):
+        assert assert_xml_element_trees_equiv(achild, bchild)
+    return True
+
+
 @pytest.mark.skipif(sys.version_info >= (3, 0), reason="requires python2")
 def test_xapi_database_filter(bugtool):
     """Assert that bugtool.DBFilter().output() filters the xAPI database as expected"""
 
     filtered = bugtool.DBFilter(original).output()
-    assert xml.dom.minidom.parseString(filtered).toprettyxml(indent="    ") == expected
+
+    # Works for Python2 equally, so we can use it to check against Python2/3 regressions:
+    assert assert_xml_element_trees_equiv(ET.fromstring(filtered), ET.fromstring(expected))
+
+    # Double-check with parseString(): Its output will differ between Py2/Py3
+    # though, so we will use it for one language version at a time:
+    if sys.version_info < (3, 0):
+        assert xml.dom.minidom.parseString(filtered).toprettyxml(indent="    ") == expected

--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -69,7 +69,7 @@ def assert_xml_element_trees_equiv(a, b):
     assert len(list(a)) == len(list(b))
     # Recursively repeat for all child nodes (expect same order of child nodes):
     for achild, bchild in zip(list(a), list(b)):
-        assert assert_xml_element_trees_equiv(achild, bchild)
+        assert_xml_element_trees_equiv(achild, bchild)
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 0), reason="requires python2")

--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -80,7 +80,7 @@ def test_xapi_database_filter(bugtool):
     filtered = bugtool.DBFilter(original).output()
 
     # Works for Python2 equally, so we can use it to check against Python2/3 regressions:
-    assert assert_xml_element_trees_equiv(ET.fromstring(filtered), ET.fromstring(expected))
+    assert_xml_element_trees_equiv(ET.fromstring(filtered), ET.fromstring(expected))
 
     # Double-check with parseString(): Its output will differ between Py2/Py3
     # though, so we will use it for one language version at a time:


### PR DESCRIPTION
## Update [tests/unit/test_xapidb_filter.py](https://github.com/xenserver/status-report/pull/30/files#diff-e72d2129c2694911731f812f6454629fa8ec8b049b7659d3ad9417eb9da6a097) to pass on Python3 too:

xen-bugtool's DBFilter class filters secrets from the XAPI database.

The test case [tests/unit/test_xapidb_filter.py](https://github.com/xenserver/status-report/pull/30/files#diff-e72d2129c2694911731f812f6454629fa8ec8b049b7659d3ad9417eb9da6a097) verifies that the `DBFilter` does the filtering of secrets correctly.

Initially, it asserted it using:
```py
assert xml.dom.minidom.parseString(filtered).toprettyxml(indent="    ") == expected
```
When used for Python3, the result of the `parseString(filtered).toprettyxml()` does not produce the same output, but the only difference is that it orders the attribute `id` as the first attribute.

This PR extends the test case to have an additional verification that works the same for Python2 and also is able to assert that the function still works in the same way for Python3:

Python3's `xml.dom.minidom.parseString()` orders the `id` attribute as the first attribute, while Python2 orders the `id` attribute not as the first attribute. Thus, use it only for Python2 or Python3 as an additional check.

Add a generic recursive assertion function to check the equivalence of the filtered XML output on Python2 and Python3 against the pre-defined expected XML output.

Review summary: @ Lindig spotted a missed check in the new equivalence XML checking function of the test, which I fixed, and he approved the change.