### PR TITLE
tests/unit/test_mdadm_arrays.py: add test for mdadm_arrays()

### DIFF
--- a/tests/integration/dom0-template/usr/sbin/mdadm
+++ b/tests/integration/dom0-template/usr/sbin/mdadm
@@ -1,2 +1,6 @@
 #!/bin/sh
-echo -n "$@"
+echo "\
+# This test data is used and expected by tests/unit/test_mdadm_arrays.py to unit-test bugtool.mdadm_arrays()
+# This configuration was auto-generated on 27 Jun 1971 08:00
+ARRAY /dev/md0 metadata=1.2 name=md0:0 UUID=74f0f4ff-06c9-4e73-b0d1-7d33a695682f
+ARRAY /dev/md1 metadata=1.3 name=md1:0 UUID=bbca0958-d6bb-46e8-93f6-4a488f7cfdce"

--- a/tests/unit/test_mdadm_arrays.py
+++ b/tests/unit/test_mdadm_arrays.py
@@ -1,0 +1,13 @@
+"""Regression tests for the bugtool helper function mdadm_arrays()"""
+import os
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 0), reason="limited to python2 until fixed")
+def test_mdadm_arrays(bugtool, testdir):
+    """Assert mdadm_arrays() returning arrays of the mdadm mockup in the dom0-template"""
+
+    os.environ["PATH"] = testdir + "/../integration/dom0-template/usr/sbin"
+    assert list(bugtool.mdadm_arrays()) == ["/dev/md0", "/dev/md1"]


### PR DESCRIPTION
`tests/unit/test_mdadm_arrays.py`: add test for `mdadm_arrays()`

Assert `mdadm_arrays()` returning the `/dev/md` arrays of the `mdadm` mockup in the `dom0-template`.