### PR TITLE
pre-commit: Don't string-normalize quotes in xen-bugtool for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .RECIPEPREFIX=>
+
+DARKER_OPTS = --isort -tpy36 --skip-string-normalization
 darker-xen-bugtool:
 >@ pip install 'darker[isort]'
 >@ tmp=`mktemp`                                       ;\
->  darker --stdout --isort -tpy36 xen-bugtool >$$tmp ||\
+>  darker --stdout $(DARKER_OPTS) xen-bugtool >$$tmp ||\
 >    exit 5                                           ;\
 >  diff -u xen-bugtool $$tmp                          ;\
 >  if [ $$? != 0 ]; then cat $$tmp >xen-bugtool       ;fi


### PR DESCRIPTION
pre-commit: When formatting staged changes for xen-bugtool, don't normalize string quotes to " for now. 