### PR TITLE
Remove not used function prettyDict()

### DIFF
--- a/tests/unit/test_fs_funcs.py
+++ b/tests/unit/test_fs_funcs.py
@@ -17,3 +17,8 @@ def test_read_inventory(bugtool, dom0_template):
 
     inventory = bugtool.readKeyValueFile(dom0_template + bugtool.XENSOURCE_INVENTORY)
     assert inventory["PRODUCT_VERSION"] == "8.3.0"
+
+
+def test_disk_list(bugtool):
+    """Assert that the return value of disk_list() contains sda or nvme0n1"""
+    assert "sda" in bugtool.disk_list() or "nvme0n1" in bugtool.disk_list()

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1993,11 +1993,6 @@ def capability(document, key):
     document.getElementsByTagName(CAP_XML_ROOT)[0].appendChild(el)
 
 
-def prettyDict(d):
-    format = '%%-%ds: %%s' % max(map(len, [k for k, _ in d.items()]))
-    return '\n'.join([format % i for i in d.items()]) + '\n'
-
-
 def yes(prompt):
     yn = input(prompt)
 


### PR DESCRIPTION
Remove not used function prettyDict()

- It is unused since 2012
- The bugtool script does not import external code such as Python plugins
- Hence, it is really unused -> remove.