### PR TITLE
Bugfix: xen-bugtool/fd_usage(): Fix TypeError when a pid disappears

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1592,7 +1592,7 @@ def fd_usage(cap):
                         fd_dict[num_fds] = []
                     fd_dict[num_fds].append(name.replace('\0', ' ').strip())
         except:
-            output += 'Error: Pid %d disappeared\n' % (d,)
+            output += "Error: Pid %s disappeared\n" % d
     keys = list(fd_dict.keys())
     keys.sort(key=int, reverse=True)
     for k in keys:

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -557,7 +557,11 @@ def func_output(cap, label, func):
 
 
 def get_recent_logs(logs, verbosity):
+    """Return list of filenames, sorted by mtime. On verbosity<9, only the first x"""
+
+    # Get the mtime of each logfile in a list of tuples and sort the tuples by mtime:
     logs = sorted([(os.stat(e).st_mtime, e) for e in logs])
+    # On verbosity<9, return the latest <verbosity> elements, otherwise all logfiles:
     return [x[1] for x in (logs[-verbosity:] if verbosity < 9 else logs)]
 
 


### PR DESCRIPTION
The fixed line caused a TypeError Exception when a pid disappeared:

- The argument "d" is a pid from os.listdir('/proc'),
  - but it is a string, not an int.
- Also, it does not need to be passed as the first element in a set.