### PR TITLE
Fix harmless warning: Close sub-archives without members as well

### DIFF
--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -61,6 +61,8 @@ def minimal_bugtool(bugtool, dom0_template, archive, subdir, mocker):
     bugtool.PLUGIN_DIR = dom0_template + "/etc/xensource/bugtool"
     bugtool.entries = ["mock"]
     archive.declare_subarchive("/etc/passwd", subdir + "/etc/passwd.tar")
+    # For code coverage: This sub-archive will not be created as it has no file
+    archive.declare_subarchive("/not/existing", subdir + "/not_created.tar")
     bugtool.load_plugins(just_capabilities=False)
     # Mock the 2nd argument of the ls -l /etc to collect it using dom0_template:
     bugtool.data["ls -l /etc"]["cmd_args"][2] = dom0_template + "/etc"

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1729,6 +1729,8 @@ class ArchiveWithTarSubarchives(object):
             if subarchive.file.getmembers():
                 subarchive.file.close()
                 self.add_path_with_data(subarchive.name, subarchive)
+            else:
+                subarchive.file.close()
 
     def add_path_with_data(self, _name, _data):
         """Implemented by the subclasses TarOutput/ZipOutput to add paths with data"""


### PR DESCRIPTION
Fix harmless warning: Close sub-archives without members:
- Fix the python (from developer mode) about not closing a sub-archive if it has got no members.
- Cover the new lines by a tiny unit test improvement.

This is based on #45 (the 1st commit) as it needs its improved coverage for unit tests to pass.