### PR TITLE
CP-45506: Fix asking if /etc/systemd/* should be collected

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1075,6 +1075,7 @@ exclude those logs from the archive.
     tree_output(CAP_XENSERVER_CONFIG, STATIC_VDIS)
     cmd_output(CAP_XENSERVER_CONFIG, [LS, '-lR', STATIC_VDIS])
     file_output(CAP_XENSERVER_CONFIG, [SYSCONFIG_CLOCK])
+    tree_output(CAP_XENSERVER_CONFIG, SYSTEMD_CONF_DIR)
     file_output(CAP_XENSERVER_CONFIG, [CGRULES_CONF])
     file_output(CAP_XENSERVER_CONFIG, [NRPE_CONF])
     tree_output(CAP_XENSERVER_CONFIG, NRPE_DIR)
@@ -1189,7 +1190,6 @@ exclude those logs from the archive.
     else:
         archive = ZipOutput(subdir)
     archive.declare_subarchive(SYSTEMD_CONF_DIR, subdir + SYSTEMD_CONF_DIR + ".tar")
-    tree_output(CAP_XENSERVER_CONFIG, SYSTEMD_CONF_DIR)
 
     # collect selected data now
     output_ts('Running commands to collect data')


### PR DESCRIPTION
Note on the test for this change:

The change in this PR is covered by two different container-based tests.

These are not unit tests, but tests which run bugtool as an external process in a container and ensure that the requested functionality is not broken by checking that /etc/systemd is still archived into a tarball inside the main bugball.

These are the links to the two lines (one for tar output archives, one for zip output archives) in the simple shell script based test (which runs inside a container) that extracts and later verifies the contents of the /etc/systemd.tar tarball in the output archive:

https://github.com/xenserver/status-report/actions/runs/7500658225/job/20419801112?pr=48#step:7:26
https://github.com/xenserver/status-report/actions/runs/7500658225/job/20419801112?pr=48#step:7:66

The same from the Python2-based namespace container test:

https://github.com/xenserver/status-report/actions/runs/7500658225/job/20419801391?pr=48#step:5:92
https://github.com/xenserver/status-report/actions/runs/7500658225/job/20419801391?pr=48#step:5:92

-----
Commit message:

For CP-45506 (Package /etc/systemd into a tarball), I had assumed
that I'd have to move the tree_output() for /etc/systemd to after
where the tarball for /etc/systemd is declared, but this was not
needed.

Moving it had the side effect that in interactive mode (a question
if each individual file shall be collected - hundreds of questions
usually), the /etc/systemd tarball was simply always collected.

This commit fixes this by reverting this move, back to the original
location of this line, to before the question if the files in
/etc/systemd/* shall be collected.