### PR TITLE
'Debug: Fix abort in debug mode on unknown entries'

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -94,7 +94,7 @@ max-attributes=11
 
 # Maximum number of branch for function / method body.
 # defaults to: max-branches=12
-max-branches=64
+max-branches=18
 
 # Maximum number of locals for function / method body.
 # defaults to: max-locals=15

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -101,6 +101,7 @@ def patch_bugtool(bugtool, mocker, dom0_template, report_name, tmp_path):
         "xenserver-config",
         "xenserver-databases",
         "mock",
+        "unknown",
     ]
     sys.argv.append("--entries=" + ",".join(entries))
     bugtool.BUG_DIR = tmp

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -648,7 +648,8 @@ Capture information to help diagnose bugs.
  -d, --debug         enable debug output
  --help              this help'''
 
-def main(argv = None):  # pylint: disable=too-many-statements
+
+def main(argv=None):  # pylint: disable=too-many-statements,too-many-branches
     global ANSWER_YES_TO_ALL, SILENT_MODE
     global entries, dbg
     global unlimited_data, unlimited_time
@@ -747,6 +748,10 @@ def main(argv = None):  # pylint: disable=too-many-statements
                 entries.append(item[0])
                 if item[0] in caps and len(item) > 1:
                     update_cap(item[0], VERBOSITY, min(9, max(1, int(item[1]))))
+            for key in entries:
+                if key not in caps:
+                    logging.warning("--entries=%s is not known!", key)
+                    entries.remove(key)
 
         # If the user runs the script with "-y" or "--yestoall" we don't ask
         # all the really annoying questions.


### PR DESCRIPTION
When status-report was executed using --debug and --entries=, and one of the entries was not known, it terminated with an error in a debug message (after it had already written the output archive).

Fix this by logging a warning for the unknown option.