### PR TITLE
GitHub CI: Fix problemMatcher to match status-report paths

### DIFF
--- a/.github/workflows/Python-problemMatcher-status-report.json
+++ b/.github/workflows/Python-problemMatcher-status-report.json
@@ -1,11 +1,11 @@
 {
   "problemMatcher": [
         {
-            "owner": "python-libs-PYTHONWARNINGS",
+            "owner": "PYTHONWARNINGS",
             "severity": "warning",
             "pattern": [
                 {
-                    "regexp": "^.*/python-libs/(.+):([0-9]*):(.*):(.*)$",
+                    "regexp": "^.*/status-report/(.+):([0-9]*):(.*):(.*)$",
                     "file": 1,
                     "line": 2,
                     "code": 3,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
       # unclosed file warnings. Configure GitHub to show all such warnings as
       # annotations at the source location they occur in the PR code review:
 
-      - run: echo "::add-matcher::.github/workflows/PYTHONWARNINGS-problemMatcher.json"
+      - run: echo "::add-matcher::.github/workflows/Python-problemMatcher-status-report.json"
 
       - uses: pre-commit/action@v3.0.0
         name: Run pre-commit checks


### PR DESCRIPTION
Minor fix for GibHub problem matching:

GitHub CI: Fix problemMatcher file to match status-report paths

It's really tiny and from what I saw in a xen-api PR where I added it the same way, this will enable GitHub to annotate the source code when PYTHONWARNINGS are issued by the Python interpreter (e.g. it will show warnings about regexes that are deprecated or invalid, not closed files from unit test runs etc)

* This should help GitHub to show annotations in the PR review in case python tests show a warning in the GitHub CI workflow output.