### PR TITLE
Backport CP-45506: Honor "n" on files in /etc/systemd/ in interactive mode

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1037,6 +1037,7 @@ exclude those logs from the archive.
     tree_output(CAP_XENSERVER_CONFIG, STATIC_VDIS)
     cmd_output(CAP_XENSERVER_CONFIG, [LS, '-lR', STATIC_VDIS])
     file_output(CAP_XENSERVER_CONFIG, [SYSCONFIG_CLOCK])
+    tree_output(CAP_XENSERVER_CONFIG, SYSTEMD_CONF_DIR)
     file_output(CAP_XENSERVER_CONFIG, [CGRULES_CONF])
     file_output(CAP_XENSERVER_CONFIG, [NRPE_CONF])
     tree_output(CAP_XENSERVER_CONFIG, NRPE_DIR)
@@ -1155,7 +1156,6 @@ exclude those logs from the archive.
     else:
         archive = ZipOutput(subdir)
     archive.declare_subarchive(SYSTEMD_CONF_DIR, subdir + SYSTEMD_CONF_DIR + ".tar")
-    tree_output(CAP_XENSERVER_CONFIG, SYSTEMD_CONF_DIR)
 
     # collect selected data now
     output_ts('Running commands to collect data')


### PR DESCRIPTION
### Backport of a fix for Yangtze: Cherry-pick a one-line fixup from master to `branches/yangtze`

#### Cherry-picks the commit https://github.com/xenserver/status-report/commit/bd32f65f3e11a66e5f4eaf9043b61684b7b540cd that is in master since three weeks into `branches/yangtze`

This is one-line revert of a change that I made for CP-45506 (Mea-culpa) that turned out to not be needed for it and turned out to change the interactive mode (when `--yes-to-all` | `-y`) is not given. In this case, interactive "`n`" answers for not collecting files in /etc/systemd to be ignored when `xenserver-status-report` is run interactively:

> For CP-45506 (Package /etc/systemd into a tarball), I had assumed that it would be needed to move the tree_output() for /etc/systemd to after where the tarball for /etc/systemd is declared, but this was not needed.
>
>Moving it had the side effect that in interactive mode (a question if each individual file shall be collected - lots of of questions), the /etc/systemd tarball was simply always collected.
>
> This commit fixes this by reverting this move, back to the original location of this line, to before the question if the files in /etc/systemd/* shall be collected.

PS: Interactive mode has got a minimal test case in the master branch, it could be used to unit-test this in the future.