### PR TITLE
README-pre-commmit.md: Document the use of the git prebase alias

### DIFF
--- a/README-pre-commmit.md
+++ b/README-pre-commmit.md
@@ -54,3 +54,42 @@ pre-commit install
 
 ### Configuring Pre-Commit Hooks to Automate Python Testing and Linting in vscode (15 mins)
 [![Configuring Pre-Commit Hooks to Automate Python Testing and Linting in vscode](https://img.youtube.com/vi/moVieAAk_xo/0.jpg)](https://www.youtube.com/watch?moVieAAk_xo)
+
+## Advanced: Run pre-commit hooks as part of `git rebase -i`
+
+For reference only:
+
+By default, `pre-commit` does not run during `git rebase` commands.
+It checks only regular commits, not amends and not rebases.
+
+When moving changes between commits while rebasing, they can get broken.
+
+To fix these issues to make them clean for `git bisect` and make each
+new commit in the stack work for itself, you can use a git alias:
+
+```ml
+[alias]
+    prebase = rebase -x 'pre-commit run --from-ref HEAD~ --to-ref HEAD'
+```
+When using `git prebase -i` instead of `git rebase -i`, pre-commit will
+run the configured commit hooks for each commit of the rebase.
+
+When the hoosk include tests such as in status-report, this ensures that tests
+also pass on each intermediate commit.
+
+Example: Commits from the end of a PR shall be postponed to a new PR:
+1. Create a copy of the branch and as a backup.
+2. Remove the commit(s) that shall be moved to a new PR.
+
+Independent on which commits this has to be done, the remaining commits
+are still unit-tested and working on their own.
+
+When, during a `git prebase -i`, a pre-commit hook fails or makes changes,
+the `rebase` stops, this is the workflow:
+- You'll see the reason of the error and get a shell.
+- You can then can check `git diff`, in case formatters fixed up the code.
+- You can then fix any errors and stage them
+- Then, run `git rebase --continue` to continue the rebase to the next step.
+
+A very helpful explanation by the Author of a book on git is here:
+https://adamj.eu/tech/2022/11/07/pre-commit-run-hooks-rebase/


### PR DESCRIPTION
Minor documentation enhancement, for reference only:

By default, `pre-commit` does not run during `git rebase` commands.
It checks only regular commits, not amends and not rebases.

When moving changes between commits while rebasing, they can get broken.

To fix these issues to make them clean for `git bisect` and make each
new commit in the stack work for itself, you can use a git alias.