### PR TITLE
Code coverage: cover both branches of filter_xenstore_secrets()

### DIFF
--- a/tests/integration/dom0-template/usr/sbin/xenstore-ls
+++ b/tests/integration/dom0-template/usr/sbin/xenstore-ls
@@ -1,0 +1,3 @@
+#!/bin/sh
+# secret_data has to be removed for security by filter_xenstore_secrets:
+echo /local/domain/1/data/set_clipboard = secret_data

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -103,6 +103,7 @@ def patch_bugtool(bugtool, mocker, dom0_template, report_name, tmp_path):
 
     # These do not have to be exact mocks, they just have to return success:
     bugtool.HA_QUERY_LIVESET = dom0_template + "/usr/sbin/mdadm"
+    bugtool.XENSTORE_LS = dom0_template + "/usr/sbin/xenstore-ls"
     bugtool.PLUGIN_DIR = dom0_template + "/etc/xensource/bugtool"
     bugtool.RPM = dom0_template + "/usr/sbin/multipathd"
     tmp = tmp_path.as_posix()
@@ -133,6 +134,7 @@ def patch_bugtool(bugtool, mocker, dom0_template, report_name, tmp_path):
 
 
 def check_output(bugtool, captured, tmp_path, filename, filetype):
+    # sourcery skip: path-read
     """Check the stdout, db and inventory output of a bugtool's main() function
 
     This function checks the output of the bugtool application to ensure that
@@ -194,6 +196,11 @@ def check_output(bugtool, captured, tmp_path, filename, filetype):
     with open(output_directory + "/xapi-db.xml") as xen_api_db:
         data = xen_api_db.read()
     test_xapidb_filter.assert_xml_str_equiv(data, test_xapidb_filter.expected)
+
+    # Assert that the captured output from the fake xenstore-ls is as expected:
+    with open(output_directory + "/xenstore-ls-f.out") as xenstore_ls_f:
+        d = xenstore_ls_f.read()
+    assert d == "/local/domain/1/data/set_clipboard = <filtered for security>\n"
 
     # Assertion check of the output files is missing an inventory entry:
     # Do this check in a future test which runs

--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -87,3 +87,9 @@ def test_xapi_database_filter(bugtool):
 
     filtered = bugtool.DBFilter(original).output()
     assert_xml_str_equiv(filtered, expected)
+
+
+def test_filter_xenstore_secrets(bugtool):
+    """Assert that filter_xenstore_secrets() does not filter non-secrets"""
+
+    assert bugtool.filter_xenstore_secrets(b"not secret", "_") == b"not secret"


### PR DESCRIPTION
Code coverage: cover both branches of filter_xenstore_secrets()

@ashwin9390 found that due to CA-136105 and CA-198975, clipboard data may no longer be in the output of `xenstore-ls -f`, (and also not in xenstored-access.log - it only seems to have the `set_clipboard` and `report_cliboard` events but no data).

If this is true, we may be able to remove the `filter_xenstore_secrets()` as the filter function for `xenstore-ls -f`, but to be safe, I'd like to get two competent confirmations/approvals for the removal of the filter.