### PR TITLE
Cosmetic clean-up of the `pytest` fixtures in tests/unit/conftest.py

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,15 @@
-"""tests/unit/conftest.py: pytest fixtures for unit-testing functions in the xen-bugtool script"""
+"""tests/unit/conftest.py: pytest fixtures for unit-testing xen-bugtool
+
+Introduction to fixtures:
+https://docs.pytest.org/en/8.0.x/fixture.html
+
+How to use fixtures:
+https://docs.pytest.org/en/8.0.x/how-to/fixtures.html
+
+The full documentation on fixtures:
+https://docs.pytest.org/en/8.0.x/reference/fixtures.html
+"""
+
 from __future__ import print_function
 
 import os
@@ -10,36 +21,31 @@ import pytest
 
 @pytest.fixture(scope="function")
 def builtins():
-    """
-    Pytest fixture to return the name of the built-in module.
-    The built-in module provides the built-in functions, exceptions, etc.
-    It is needed to replace built-in functions like open() with a new mock.
-
-    :returns (str): The name of the built-in module.
-    """
+    """Provide the builtins module name for Python 2.x and Python 3.x"""
     return "__builtin__" if sys.version_info < (3,) else "builtins"
 
 
 @pytest.fixture(scope="session")
 def testdir():
-    """Test fixture to get the directory of the unit test for finding other files relative to it"""
+    """Test fixture to provide the directory of the dom0 template directory"""
     return os.path.dirname(__file__)
 
 
 @pytest.fixture(scope="session")
 def dom0_template(testdir):
-    """Test fixture to get the directory of the dom0 template and adding it's /usr/sbin to the PATH"""
+    """Test fixture to get the directory of the dom0 template"""
     return testdir + "/../integration/dom0-template"
 
 
 @pytest.fixture(scope="session")
 def imported_bugtool(testdir, dom0_template):
-    """Test fixture to import the xen-bugtool script as a module for executing unit tests on functions"""
+    """Fixture to provide the xen-bugtool script as a module for unit tests"""
 
-    # This uses the deprecated imp module because it needs also to run with Python2.7 for now:
     def import_from_file(module_name, file_path):
         if sys.version_info.major == 2:  # pragma: no cover
-            import imp  # pylint: disable=deprecated-module  # pyright: ignore[reportMissingImports]
+            # Python 2.7, use the deprecated imp module (no alternative)
+            # pylint: disable-next=deprecated-module
+            import imp  # pyright: ignore[reportMissingImports]
 
             module = imp.load_source(module_name, file_path)
 
@@ -47,8 +53,6 @@ def imported_bugtool(testdir, dom0_template):
             sys.modules[module_name] = module
             return module
         else:
-            # Py3.11+: Importing Python source code from a script without the .py extension:
-            # https://gist.github.com/bernhardkaindl/1aaa04ea925fdc36c40d031491957fd3:
             from importlib import machinery, util
 
             loader = machinery.SourceFileLoader(module_name, file_path)
@@ -64,9 +68,11 @@ def imported_bugtool(testdir, dom0_template):
 
     bugtool = import_from_file("xen-bugtool", testdir + "/../../xen-bugtool")
     bugtool.ProcOutput.debug = True
+
     # Prepend tests/mocks to force the use of our mock xen.lowlevel.xc module:
     sys.path.insert(0, testdir + "/../mocks")
     os.environ["PATH"] = dom0_template + "/usr/sbin"  # for modinfo, mdadm, etc
+
     return bugtool
 
 


### PR DESCRIPTION
This only changes the refactors file `tests/units/conftest.py`
- it is the local `pytest` fixtures for this directory
- and the changes do not break the tests in any way. 

For a clean review, I refactored the Refactoring part from #67 into the PR.

It follows the TDD model of
- Add failing test
- Fix the code and switch the test to pass
- Refactor (this PR - but these are only cosmetic updates) <---------------------------

Everything here already has 100.00% code coverage (the every file in `tests/unit/*` is 100.00% covered)

It is split into two commits, the 1st for actual refactoring:
- nothing is moved
- just tiny improvements from review comments

And the 2nd commit is only comments and `docstring` clean-up to shorten them - doc is n #68.

-----

- This PR contains two overlapping commits on the same file,

- conftest.py is the local `pytest` plugin, used only by the tests in tests/unit, it does not change the product itself.
  - See the new, proposed README.md for more information what the conftest.py contains:
    https://github.com/xenserver-next/status-report/blob/add-tests-unit-conftest-README.md/tests/unit/conftest-README.md

Commits:
---------
- [tests/unit/conftest.py: Minor refactoring of the test fixtures](https://github.com/xenserver/status-report/commit/9338d3eed2d4d01ae8d1583c03b6a5b4e2a55fcc)
  - Apply code refactoring from reviews:
    - Change 1 and 2: Use if-expressions where applicable
    - Change 3: For consistency, add the imported module to `sys.modules` for Py2 as well
    - Change 4: Change import_bugroot into a yielding fixture. After return,
      - reset the `bugtool.data` dict and
      - reset `sys.argv[]` to a good default argument as clean-up.

- [tests/unit/conftest.py: Shorten `docstrings` to fit into 88 columns](https://github.com/xenserver/status-report/commit/6bf2675089312d990c127245d5600848cbbed05d)
  - Clean-up the `docstrings` and comments
  - Shorten the commits to fit into 88 columns,
    - Plan: The goal is to transition to shorter page width of the code.
  - Clean-up not important comments and docstrings, see:
    - #68 for a dedicated `README.md` for `tests/unit/conftest.py`)
    - It provides the reference documentation using these fixtures in tests now.
