### PR TITLE
Restore coverage upload to codecov (falls back to legacy uploader), add coveralls upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 env:
+  # Setup Coveralls to for parallel coverage upload from python2 and 3 workflows
+  COVERALLS_PARALLEL: true
   DEBIAN_FRONTEND: noninteractive
   # No warnings for pip and pytest themselves; pytest enables warnings in conftest.py
   PYTHONWARNINGS: ignore
@@ -120,6 +122,13 @@ jobs:
           unique-id-for-comment: pytest-coverage-python27
           title: Pytest Code coverage comment for Python 2.7
 
+      - name: Upload coverage reports to Coveralls
+        env:
+          COVERALLS_FLAG_NAME: python2.7
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz
+          ./coveralls --service-name=github
 
   pre-commit:
     name: "Python3: Pre-Commit Suite"
@@ -210,3 +219,10 @@ jobs:
           title: >
             Python3 coverage comment from
             https://github.com/marketplace/actions/pytest-coverage-comment
+
+
+      - name: Upload coverage reports to Coveralls
+        env:
+          COVERALLS_FLAG_NAME: ${{ format('python{0}', steps.python.outputs.python-version ) }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pip install coveralls && coveralls --service=github && coveralls --finish || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,14 @@
 # podman system service -t 0 &
 # act --bind --container-daemon-socket $XDG_RUNTIME_DIR/podman/podman.sock -W .github/workflows/main.yml
 #--------------------------------------------------------------------------------------
-name: "GitHub CI"
+name: "Pytest test suites"
 
+#
 # The GitHub events that trigger this workflow:
 # Checks can be skipped by adding "skip-checks: true" to a commit message,
 # or requested by adding "request-checks: true" if disabled by default for pushes:
 # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#skipping-and-requesting-checks-for-individual-commits
+#
 on: [push, pull_request]
 
 # Docs: https://github.com/marketplace/actions/commit-status-updater#workflow-permissions
@@ -21,9 +23,11 @@ permissions:
   pull-requests: write  # creating a comment
   statuses: write  #  # updating commit status
 
+#
 # Cancel a currently running workflow from the same PR, branch or tag
 # when a new workflow is triggered:
 # https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
+#
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -57,12 +61,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: LizardByte/setup-python-action@master
+        with:
+          python-version: 2.7
+
       - name: Install dependencies
         run: |
-          #: Install Python 2.7 from Ubuntu 20.04 using apt-get install
-          sudo apt-get update && sudo apt-get install -y python2
-          curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
-          python2 get-pip.py
           if [ -f requirements.txt ]; then pip2 install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip2 install -r requirements-dev.txt; fi
           pip2 install pylint==1.9.4
@@ -76,12 +80,24 @@ jobs:
           --cov tests/
           --junitxml=.git/pytest27.xml
           --cov-report term-missing
-          --cov-report html:.git/coverage27.html
           --cov-report xml:.git/coverage27.xml
 
       - name: Upload coverage reports to Codecov for the Python 2.7 tests
-        if: ${{ github.actor != 'nektos/act' && github.event.pull_request.number }}
-        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: env.CODECOV_TOKEN && !cancelled() && github.event.pull_request.number
+        run: >
+          rm -rfv codecov;curl -O https://cli.codecov.io/latest/linux/codecov &&
+          sudo chmod +x codecov && ./codecov upload-process --report-type coverage
+          --git-service github --fail-on-error --dir .git --file coverage27.xml
+          --flag python2.7 --name "Python 2.7 for main"
+        continue-on-error: true
+
+
+      - name: Upload coverage reports to Codecov for the Python 2.7 tests
+        # If CODECOV_TOKEN is not set, use the legacy tokenless codecov action:
+        if: ${{ !env.CODECOV_TOKEN && github.event.pull_request.number }}
+        uses: codecov/codecov-action@v3
         env:
           PYTHON: python2.7
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -91,7 +107,7 @@ jobs:
           flags: python2.7
           env_vars: OS,PYTHON
           fail_ci_if_error: false
-          name: coverage27
+          name: "Python 2.7 for main"
           verbose: true
 
       - name: Add Pytest 2.7 coverage comment (if write permission is available)
@@ -152,8 +168,24 @@ jobs:
           SKIP: no-commit-to-branch
 
       - name: Upload coverage reports to Codecov
-        if: ${{ github.actor != 'nektos/act' && github.event.pull_request.number }}
-        uses: codecov/codecov-action@v4
+        # If CODECOV_TOKEN is set, use the new codecov CLI to upload the coverage reports
+        if: ${{ env.CODECOV_TOKEN && !cancelled() && github.event.pull_request.number }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: >
+          pip install codecov-cli && codecovcli upload-process --report-type coverage
+          --git-service github --fail-on-error --dir .git --file coverage.xml
+          --flag python${{ steps.python.outputs.python-version }}
+          --name "Python 3.x for main"
+        continue-on-error: true
+
+
+      - name: Upload coverage reports to Codecov (legacy Node.js 16 action)
+        # If CODECOV_TOKEN is not set, use the legacy tokenless codecov action:
+        if: ${{ !env.CODECOV_TOKEN && github.event.pull_request.number }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v3
         with:
           directory: .git
           env_vars: OS,PYTHON
@@ -163,10 +195,9 @@ jobs:
           fail_ci_if_error: false
           flags: >
             ${{ format('python{0}', steps.python.outputs.python-version ) }}
-          name: coverage
+          name: "Python 3.x for main"
           verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 
       - name: Add Pytest coverage comment (if write permission is available)
         if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.number }}


### PR DESCRIPTION
Two commits here:
- they don't overlap the same lines
- They make their change twice because we upload coverage with the python2.7 and python3.<whatever version> to coverage databases (coverity.io / coveralls.io)
- they only alternate within the same file 

The commits are:
- [CodeCov: Use the CLI if the token is set, else the legacy action](https://github.com/xenserver/status-report/commit/3d8245db0d4fb523d4f974530c9cebed219fe2ce)
  - restores coverage upload to coverity:
    - the new uploaded needs the Codecov Upload Token that isn't set up yet, restores coverity upload
    - Upload to Coverity is fixed, but does not show the coverage because the fork-point of this PR had no working coverage upload to compare coverage against.
- [Coveralls: Add coverage upload to coveralls.io](https://github.com/xenserver/status-report/commit/5e470406d43010e6e0a83a95d9b7d70bfdabb2b2)