### PR TITLE
Improve readablity of integration tests

### DIFF
--- a/tests/integration/namespace_container.py
+++ b/tests/integration/namespace_container.py
@@ -1,4 +1,5 @@
-"""namespace_container.py: Functions for creating a test environment container on any Linux and GitHub CI"""
+"""Functions for creating a test environment container on any Linux and GitHub CI"""
+
 import ctypes
 import os
 
@@ -22,7 +23,7 @@ def unshare(flags):
 
 
 def mount(source="none", target="", fs="", flags=0, options=""):
-    """Wrapper for the Linux libc/system call to mount an fs, supports Python2.7 and Python3.x"""
+    """Wrapper for the Linux libc/system call to mount an fs"""
     libc = ctypes.CDLL(None, use_errno=True)
     libc.mount.argtypes = (
         ctypes.c_char_p,
@@ -35,11 +36,14 @@ def mount(source="none", target="", fs="", flags=0, options=""):
     result = libc.mount(source.encode(), target.encode(), fs.encode(), flags, options.encode())
     if result < 0:  # pragma: no cover
         errno = ctypes.get_errno()
-        raise OSError(errno, "mount " + target + " (options=" + options + "): " + os.strerror(errno))
+        raise OSError(
+            errno,
+            "mount " + target + " (options=" + options + "): " + os.strerror(errno),
+        )
 
 
 def umount(target):
-    """Wrapper for the Linux umount system call, supports Python2.7 and Python3.x"""
+    """Wrapper for the Linux umount system call"""
     libc = ctypes.CDLL(None, use_errno=True)
     result = libc.umount(ctypes.c_char_p(target.encode()))
     if result < 0:  # pragma: no cover
@@ -48,38 +52,63 @@ def umount(target):
 
 
 def activate_private_test_namespace(bindmount_root, bindmount_mountpoints):
-    """Activate a new private mount, network and user namespace with the user behaving like uid 0 (root)
+    """Enter a new Linux namespace
 
-    xen-bugtool requires to be run as root and checks it and writes its output to /var/opt/xen/bug-report.
-    The container setup provides these root privileges and a new mount namespace to bind-mount the test files.
-    It allows to bind-mount the directory trees with test files at the places where xen-bugtool collects them.
-    The mount namespace also allows to create a tmpfs mount at /var/opt/xen/bug-report for the output data.
-    It avoids the need to create a temporary directory and to bind-mount it into the container.
-    Additionally, it ensures that no temporary data can accumulate on the host.
+    xen-bugtool requires to be run as root and checks it
+    and writes its output to /var/opt/xen/bug-report.
 
-    This function implements the equivalent of `/usr/bin/unshare --map-root-user --mount --net`
+    The namespace provides root privileges and a new mount namespace
+    to bind-mount the test files.
+
+    It allows to bind-mount the directory trees with test files at the places
+    where xen-bugtool collects them.  The mount namespace also allows to create
+    a tmpfs mount at /var/opt/xen/bug-report for the output data.
+
+    This function implements the equivalent of:
+    `/usr/bin/unshare --map-root-user --mount --net`
     and mounts the passed bindmount_mountpoints below bindmount_root:
 
-    - --map-root-user: Create a user namespace where euid/egid are mapped to the superuser UID and GID.
-    - --mount: Create a Linux mount namespace for mounting temporary file systems and bind-mounting test data.
-    - --net: Create a Linux network namespace to ensure that `bugtool` works without outside connectivity.
+    - --map-root-user: Maps euid/egid are mapped to the superuser UID and GID
+    - --mount: Allow mounting temporary file systems and bind-mounting test data
     """
-    # Implements the sequence that `unshare -rmn <command>` uses. Namespace is active even without fork():
+
+    #
+    # Implements the sequence that `unshare -rmn <command>` uses.
+    # The Namespace is active even without fork():
+    #
     real_uid = os.getuid()
     real_gid = os.getgid()
     unshare(CLONE_NEWUSER | CLONE_NEWNET | CLONE_NEWNS)
-    # Setup uidmap for the user's uid to behave like uid 0 would (eg for bugtool's root user check)
+
+    #
+    # Setup uidmap for the user's uid to behave like uid 0 would
+    # (eg for bugtool's root user check)
+    #
     with open("/proc/self/uid_map", "wb") as proc_self_uidmap:
         proc_self_uidmap.write(b"0 %d 1" % real_uid)
-    # Setup setgroups behave like gid 0 would (needed for new tmpfs mounts for test output files):
+    #
+    # Setup setgroups behave like gid 0 would
+    # (needed for new tmpfs mounts for test output files):
+    #
     with open("/proc/self/setgroups", "wb") as proc_self_setgroups:
         proc_self_setgroups.write(b"deny")
-    # Setup gidmap for the user's gid to behave like gid 0 would (needed for tmpfs mounts):
+
+    #
+    # Setup gidmap for the user's gid to behave like gid 0 would
+    # (needed for tmpfs mounts):
     with open("/proc/self/gid_map", "wb") as proc_self_gidmap:
         proc_self_gidmap.write(b"0 %d 1" % real_gid)
-    # Prepare a private root mount in the new mount namespace, needed for mounting a private tmpfs on /var:
+
+    #
+    # Prepare a private root mount in the new mount namespace,
+    # needed for mounting a private tmpfs on /var:
+    #
     mount(target="/", flags=MS_REC | MS_PRIVATE)
-    # Bind-mount the Dom0 template directories in the private mount namespace to provide the test files:
+
+    #
+    # Bind-mount the Dom0 template directories in the private mount namespace
+    # to provide the test files:
+    #
     for mountpoint in bindmount_mountpoints:
         if not os.path.exists(mountpoint):
             raise RuntimeError("Mountpoint missing on host! Please run: sudo mkdir " + mountpoint)

--- a/tests/integration/test_system_load.py
+++ b/tests/integration/test_system_load.py
@@ -1,13 +1,19 @@
 """tests/integration/test_system_load.py: Test xen-bugtool --entries=system-load"""
+
 import os
 
-from .utils import assert_file, run_bugtool_entry, assert_content_from_dom0_template
+from .utils import (
+    assert_file,
+    run_bugtool_entry,
+    assert_content_from_dom0_template,
+)
 
 
 # In this test case we need to sleep for 1 sec, and it is sufficient
 # to test to only with zip archives to keep the test duration short:
 def test_system_load(output_archive_type="zip"):
-    """Test xen-bugtool --entries=system-load in test jail created by auto-fixtures in conftest.py"""
+    """Test xen-bugtool --entries=system-load"""
+
     entry = "system-load"
 
     # Create test input files:

--- a/tests/integration/test_xenserver_config.py
+++ b/tests/integration/test_xenserver_config.py
@@ -1,26 +1,41 @@
-"""tests/integration/test_xenserver_config.py: Test xen-bugtool --entries=xenserver-config"""
+"""Test xen-bugtool --entries=server-config"""
+
 import os
 
-from .utils import assert_cmd, assert_file, run_bugtool_entry, assert_content_from_dom0_template
+from .utils import (
+    assert_cmd,
+    assert_file,
+    run_bugtool_entry,
+    assert_content_from_dom0_template,
+)
 
 
 def test_xenserver_config(output_archive_type):
-    """Test xen-bugtool --entries=xenserver-config in test jail created by auto-fixtures in conftest.py"""
+    """
+    Run xen-bugtool --entries=xenserver-config in test jail
+    (created by auto-fixtures, see README-pytest-chroot.md)
+    """
     entry = "xenserver-config"
 
     run_bugtool_entry(output_archive_type, entry)
 
-    # Assert that the bugtool output archive of --entries=xenserver-config matches our expectations for it:
+    # Check the output of xen-bugtool --entries=xenserver-config:
+
     assert_file("ls-lR-%opt%xensource.out", "/opt/xensource:", only_first_line=True)
     assert_file("ls-lR-%etc%xensource%static-vdis.out", "")
     assert_file("static-vdis-list.out", "list")
 
     # Assert the contents of the extracted etc/systemd.tar
+
+    # etc/systemd.tar's toplevel directory is os.environ["XENRT_BUGTOOL_BASENAME"]
     os.chdir("..")
-    # etc/systemd.tar's toplevel directory is os.environ["XENRT_BUGTOOL_BASENAME"] (= entries for the test)
+
+    # Extract the etc/systemd.tar file:
     assert_cmd(["tar", "xvf", entry + "/etc/systemd.tar"], entry + "/etc/systemd.tar")
 
+    # Change back to the bugtool output to check the etc/systemd directory:
     os.chdir(entry)
+
     assert_content_from_dom0_template("etc/systemd")
     assert_content_from_dom0_template("etc/xensource-inventory")
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,4 +1,5 @@
-"""tests/integration/utils.py: utility functions to test xen-bugtool by invoking it"""
+"""Utility functions to test xen-bugtool without any mocking"""
+
 from __future__ import print_function
 
 import filecmp
@@ -12,8 +13,8 @@ from subprocess import PIPE, Popen
 from lxml.etree import XMLSchema, parse  # pytype: disable=import-error
 
 # pyright: ignore[reportMissingImports]
-if sys.version_info.major == 2:
-    from commands import getstatusoutput  # type:ignore[import-not-found] # pragma: no cover
+if sys.version_info.major == 2:  # pragma: no cover
+    from commands import getstatusoutput  # type:ignore[import-not-found]
 else:
     from subprocess import getstatusoutput
 
@@ -34,10 +35,17 @@ def run(command):
 
 
 def assert_cmd(cmd, remove_file):
-    """Run the given command, print its stdout and stderr and return them. Remove the given remove_file"""
+    """Run the given command, print its stdout and stderr and return them.
+
+    Removes the given remove_file, the checks at the end of the tests cases
+    expect all tested files to be removed, so they will discover file which
+    have not been checked.
+    """
+
     # If something causes an Exception, the remove_file will not be removed and
     # this will cause a final test failure check to trip and fail the test too:
     stdout, stderr = run(cmd)
+
     # After successful verification of the file, remove the checked output file:
     os.unlink(remove_file)
     return stdout, stderr
@@ -55,9 +63,11 @@ def assert_file(path, expected, only_first_line=False):
             print(error_msg)
             print("- " + expected)
             print("+ " + read_data)
+            #
             # Exit with an exception, and the file with unexpected contents
             # is also kept. Any files that are left in the extracted directory
             # will cause a final test failure check to trip and fail the test too:
+            #
             assert RuntimeError(error_msg)
 
     # After successful verification of the file, remove the checked output file:
@@ -82,7 +92,12 @@ def assert_content_from_dom0_template(path, control_path=None):
         if not filecmp.cmp(path, control):
             os.system("diff -u %s %s" % (path, control))  # pragma: no cover
             raise AssertionError("/%s from report has different content" % path)
-    # Remove verified output files/directories. Untested files will remain and cause the testcase to FAIL:
+    #
+    # Remove the verified files and diretories.
+    #
+    # The checks at the end of the tests cases expect all tested files to be removed,
+    # so they will discover file which files have not been checked by the test.
+    #
     try:
         os.unlink(path)
     except OSError:
@@ -93,7 +108,8 @@ def extract(zip_or_tar_archive, archive_type):  # pragma: no cover
     """Extract a passed zip, tar or tar.bz2 archive into the current working directory"""
     if sys.version_info > (3, 0):
         if archive_type == "zip" and os.environ.get("GITHUB_ACTION"):
-            run(["unzip", zip_or_tar_archive])  # GitHub's Py3 is missing cp437 for unpack_archive()
+            # GitHub's Python3 is missing cp437 for unpack_archive()
+            run(["unzip", zip_or_tar_archive])
         else:
             shutil.unpack_archive(zip_or_tar_archive)
     else:  # Python2.7 does not have shutil.unpack_archive():
@@ -111,7 +127,15 @@ def extract(zip_or_tar_archive, archive_type):  # pragma: no cover
 
 
 def run_bugtool_entry(archive_type, test_entries):
-    """Run bugtool for the given entry or entries, extract the output, and chdir to it"""
+    """
+    Execute the bugtool script with the given entries and prepare testing it.
+
+    Prepare testing the output by exctracting the bugball and switch into it.
+    - Also validate the XMLSchema if the extracted inventory.xml so all tests
+      have that check automatically.
+    - Also create a symlink as ./tests that allows test cases to get test files.
+    """
+
     os.environ["XENRT_BUGTOOL_BASENAME"] = test_entries
 
     command = "python%s ./xen-bugtool -y --output=%s --entries=%s" % (
@@ -121,13 +145,26 @@ def run_bugtool_entry(archive_type, test_entries):
     )
     print("# " + command)
     error_code, output = getstatusoutput(command)
+
     print(output)
     if error_code:
         raise RuntimeError(output)
+
     src_dir = os.getcwd()
+
+    #
+    # Switch to the BUGTOOL_OUTPUT_DIR and extract the bugball in it.
+    #
+    # Because the test framework uses a tmpfs for it, it won't clutter
+    # the development systems.
+    #
+    # This function leaves with the cwd in it for checking the output
+    # data.
+    #
     os.chdir(BUGTOOL_OUTPUT_DIR)
     extract(test_entries + "." + archive_type, archive_type)
     os.chdir(test_entries)
+
     # Validate the extracted inventory.xml using the XML schema from the test framework:
     with open(src_dir + "/tests/integration/inventory.xsd") as xml_schema:
         XMLSchema(parse(xml_schema)).assertValid(parse("inventory.xml"))

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -113,8 +113,12 @@ def extract(zip_or_tar_archive, archive_type):  # pragma: no cover
 def run_bugtool_entry(archive_type, test_entries):
     """Run bugtool for the given entry or entries, extract the output, and chdir to it"""
     os.environ["XENRT_BUGTOOL_BASENAME"] = test_entries
-    # For case the default python interpreter of the user is python3, we must use python2(for now):
-    command = "python2 ./xen-bugtool -y --output=%s --entries=%s" % (archive_type, test_entries)
+
+    command = "python%s ./xen-bugtool -y --output=%s --entries=%s" % (
+        sys.version_info.major,
+        archive_type,
+        test_entries,
+    )
     print("# " + command)
     error_code, output = getstatusoutput(command)
     print(output)
@@ -122,9 +126,7 @@ def run_bugtool_entry(archive_type, test_entries):
         raise RuntimeError(output)
     src_dir = os.getcwd()
     os.chdir(BUGTOOL_OUTPUT_DIR)
-    output_file = test_entries + "." + archive_type
-    print("# Unpacking " + BUGTOOL_OUTPUT_DIR + output_file + " and verifying inventory.xml")
-    extract(output_file, archive_type)
+    extract(test_entries + "." + archive_type, archive_type)
     os.chdir(test_entries)
     # Validate the extracted inventory.xml using the XML schema from the test framework:
     with open(src_dir + "/tests/integration/inventory.xsd") as xml_schema:


### PR DESCRIPTION
Use the Commits tab to review the fix for the integration test independent of the formatting changes in commit #2
- [Fix integration test to use python2+3](https://github.com/xenserver/status-report/commit/2b018d07733686c4f0782e10ecd72fd61a32dc1f)
  - I also added the clean-up of a logging print() in the test that is not that much needed here.

- [Improve readability of the code, limit to 88 columns](https://github.com/xenserver/status-report/commit/acded429336a1e3453ce82884061d0994f73da08)
  - This does not change code in any way, it only improves the comments not exceed 88 colums.

PS: At some later point, black will do the remaining work with (code with 88 columns is more readable):
```py
  [tool.black]
- line-length = 108
+ line-length = 88
```