### PR TITLE
CA-388587: Backport from master: Fix filtering the xapi-clusterd db and log any errors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,34 @@
+[run]
+source =
+       xen-bugtool
+       tests/
+
+[report]
+# Regular expressions for lines to exclude from consideration
+exclude_lines =
+    # Don't complain if tests don't hit catch-all exception handlers:
+    except:
+    except Exception
+    except IOError
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Enable these selectively if you want to allow these raises without cover:
+    # (If you want no complaint when tests don't hit raising these Assertions)
+    # raise AssertionError
+    # raise NotImplementedError
+    # raise RuntimeError
+    # raise ValueError
+    # \<assert\>.*
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    # skip any line with a `pass` (such as may be used for @abstractmethod or @suffixed_method)
+    pass
+
+precision = 1
+include =
+    xen-bugtool
+    tests/*

--- a/.github/workflows/alpine-python2.yml
+++ b/.github/workflows/alpine-python2.yml
@@ -6,7 +6,7 @@
 # podman system service -t 0 &
 # act --bind --container-daemon-socket $XDG_RUNTIME_DIR/podman/podman.sock -W .github/workflows/main.yml
 #--------------------------------------------------------------------------------------
-name: Python 2
+name: Shell script tests
 
 # Cancel a currently running workflow from the same PR, branch or tag
 # when a new workflow is triggered:
@@ -36,7 +36,7 @@ jobs:
       matrix:
         python-version: ["2.7"]  # Newer versions will be added during python2to3 work
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install test tools
         run: apk add --no-cache libxml2-utils bash
       - name: Install python requirements

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,28 +1,127 @@
-name: Build and test
+#--------------------------------------------------------------------------------------
+# This GitHub Actions workflow can be run locally using https://github.com/nektos/act
+#
+# act normally uses docker, but it can also be run using podman on Fedora 37:
+# dnf install act-cli podman
+# podman system service -t 0 &
+# act --bind --container-daemon-socket $XDG_RUNTIME_DIR/podman/podman.sock -W .github/workflows/main.yml
+#--------------------------------------------------------------------------------------
+name: "Pytest test suites"
 
-on:
-  push:
-  pull_request:
+#
+# The GitHub events that trigger this workflow:
+# Checks can be skipped by adding "skip-checks: true" to a commit message,
+# or requested by adding "request-checks: true" if disabled by default for pushes:
+# https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#skipping-and-requesting-checks-for-individual-commits
+#
+on: [push, pull_request]
 
+
+#
+# Cancel a currently running workflow from the same PR, branch or tag
+# when a new workflow is triggered:
+# https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
+#
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  # No warnings for pip and pytest themselves; pytest enables warnings in conftest.py
+  PYTHONWARNINGS: ignore
 jobs:
-  python-checks:
-    name: Python checks
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
+  container-tests:
+    name: "Python2: Container tests"
+    runs-on: ubuntu-22.04
+    # https://github.com/Docker-Hub-frolvlad/docker-alpine-python2
+    container: frolvlad/alpine-python2
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Install test tools
+        run: apk add --no-cache libxml2-utils bash
+      - name: Install python requirements
+        run: pip install -r requirements.txt
+      - name: Test sar file collection, extended by XSI-1385 with plain-text SARs
+        run: bash -x tests/integration/sar-file-collection.test.sh
+      - name: Test creating a tarball for /etc/systemd
+        run: bash -x tests/integration/xenserver-config-systemd.sh
+
+  python2-tests:
+    name: "Python2: PyLint and Pytest"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
           #: Install Python 2.7 from Ubuntu 20.04 using apt-get install
-          sudo apt-get update && sudo apt-get install -y python2-dev
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-          pip install pylint==1.9.4
+          sudo apt-get update && sudo apt-get install -y python2
+          curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
+          python2 get-pip.py
+          if [ -f requirements.txt ]; then pip2 install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip2 install -r requirements-dev.txt; fi
+          pip2 install pylint==1.9.4
 
       - name: Run pylint-1.9.4 for pylint --py3k linting (configured in .pylintrc)
-        if: ${{ matrix.python-version == 2.7 }}
+        run: python2 -m pylint xen-bugtool
+      - name: Run python2 -m pytest to execute all unit and integration tests
+        run: >
+          python2 -m pytest -v -rA
+          --cov xen-bugtool
+          --cov tests/
+          --junitxml=.git/pytest27.xml
+          --cov-report term-missing
+          --cov-report html:.git/coverage27.html
+          --cov-report xml:.git/coverage27.xml
+
+      - name: Upload coverage reports to Codecov for the Python 2.7 tests
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: env.CODECOV_TOKEN && !cancelled() && github.event.pull_request.number
+        run: >
+          curl -Os https://cli.codecov.io/latest/linux/codecov &&
+          sudo chmod +x codecov &&
+          ./codecov do-upload --report-type test_results
+          --file .git/pytest27.xml
+          --token $CODECOV_TOKEN &&
+          ./codecov do-upload --report-type coverage
+          --file .git/coverage27.xml
+          --flags python2.7
+          --token $CODECOV_TOKEN
+        continue-on-error: true
+
+
+      - name: Upload coverage reports to Codecov for the Python 2.7 tests
+        # If CODECOV_TOKEN is not set, use the legacy tokenless codecov action:
+        if: ${{ !env.CODECOV_TOKEN && github.event.pull_request.number }}
+        uses: codecov/codecov-action@v3
+        env:
+          PYTHON: python2.7
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          directory: .git
+          files: coverage27.xml
+          flags: python2.7
+          env_vars: OS,PYTHON
+          fail_ci_if_error: false
+          name: coverage27
+          verbose: true
+
+      - name: Add Pytest 2.7 coverage comment (if write permission is available)
+        if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.number }}
+        uses: MishaKav/pytest-coverage-comment@main
+        continue-on-error: true
+        with:
+          junitxml-path: .git/pytest27.xml
+          pytest-xml-coverage-path: .git/coverage27.xml
+          unique-id-for-comment: pytest-coverage-python27
+          title: Pytest Code coverage comment for Python 2.7
+
+      - name: Upload coverage reports to Coveralls
+        env:
+          COVERALLS_FLAG_NAME: python2.7
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pylint xen-bugtool
+          curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz
+          ./coveralls --service-name=github

--- a/.pylintrc
+++ b/.pylintrc
@@ -92,7 +92,7 @@ max-attributes=11
 
 # Maximum number of branch for function / method body.
 # defaults to: max-branches=12
-max-branches=62
+max-branches=64
 
 # Maximum number of locals for function / method body.
 # defaults to: max-locals=15

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,32 @@
+[pytest]
+# By default, show reports for failed tests:
+addopts=-rF
+# imp is only used in a unit test, will be updated to python3 later:
+filterwarnings=ignore:the imp module is deprecated
+# Enable live logging of the python log output, starting with log level INFO by default:
+log_cli=True
+log_cli_level=INFO
+# By default, run the tests in the tests directory:
+testpaths=tests/
+
+#
+# Make @pytest.mark.xfail(strict=True) the default:
+#
+# pytest.mark.xfail(strict=True) will fail if the test passes, but the default
+# is to not fail if the test passes.
+#
+# This is a problem because it can lead to tests that are marked as XFAIL, but
+# are actually passing, and we don't notice because they are marked as XFAIL.
+#
+# For example, if we have a test that is marked as XFAIL, but it passes, we
+# will see a XPASS instead of a FAILED. This is a problem because we don't
+# notice that the test is actually passing, and we don't update the test to
+# now be fixed and require it to pass instead from now on.
+#
+# To fix this, we can set the strict parameter to True, so that if a test is
+# marked as XFAIL, but passes, it will fail. This way, we will see a FAILED
+# instead of a PASSED (or XPASS).
+#
+# Make @pytest.mark.xfail(strict=True) the default:
+#
+xfail_strict=True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+lxml
+pytest-coverage
+pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-defusedxml==0.5.0
+# Initially, xen-bugtool was deployed in xs8 using defusedxml==0.5.0.
+# The common python-defusedxml.srpm has since been updated to the current
+# defusedxml-0.7.1.
+# Tests should now use this version:
+defusedxml==0.7.1

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,90 @@
+"""tests/unit/conftest.py: pytest fixtures for unit-testing xen-bugtool
+
+Introduction to fixtures:
+https://docs.pytest.org/en/8.0.x/fixture.html
+
+How to use fixtures:
+https://docs.pytest.org/en/8.0.x/how-to/fixtures.html
+
+The full documentation on fixtures:
+https://docs.pytest.org/en/8.0.x/reference/fixtures.html
+"""
+
+from __future__ import print_function
+
+import os
+import shutil
+import sys
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def builtins():
+    """Provide the builtins module name for Python 2.x and Python 3.x"""
+    return "__builtin__" if sys.version_info < (3,) else "builtins"
+
+
+@pytest.fixture(scope="session")
+def testdir():
+    """Test fixture to provide the directory of the dom0 template directory"""
+    return os.path.dirname(__file__)
+
+
+@pytest.fixture(scope="session")
+def dom0_template(testdir):
+    """Test fixture to get the directory of the dom0 template"""
+    return testdir + "/../integration/dom0-template"
+
+
+@pytest.fixture(scope="session")
+def imported_bugtool(testdir, dom0_template):
+    """Fixture to provide the xen-bugtool script as a module for unit tests"""
+
+    def import_from_file(module_name, file_path):
+        if sys.version_info.major == 2:  # pragma: no cover
+            # Python 2.7, use the deprecated imp module (no alternative)
+            # pylint: disable-next=deprecated-module
+            import imp  # pyright: ignore[reportMissingImports]
+
+            module = imp.load_source(module_name, file_path)
+
+            # Prevent other code from importing the same module again:
+            sys.modules[module_name] = module
+            return module
+        else:
+            from importlib import machinery, util
+
+            loader = machinery.SourceFileLoader(module_name, file_path)
+            spec = util.spec_from_loader(module_name, loader)
+            assert spec
+            assert spec.loader
+            module = util.module_from_spec(spec)
+
+            # Prevent other code from importing the same module again:
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+            return module
+
+    bugtool = import_from_file("xen-bugtool", testdir + "/../../xen-bugtool")
+    bugtool.ProcOutput.debug = True
+
+    # Prepend tests/mocks to force the use of our mock xen.lowlevel.xc module:
+    sys.path.insert(0, testdir + "/../mocks")
+    os.environ["PATH"] = dom0_template + "/usr/sbin"  # for modinfo, mdadm, etc
+
+    return bugtool
+
+
+@pytest.fixture(scope="function")
+def bugtool(imported_bugtool):
+    """Test fixture for unit tests, initializes the bugtool data dict for each test"""
+    # Init import_bugtool.data, so each unit test function gets it pristine:
+    imported_bugtool.data = {}
+    sys.argv = ["xen-bugtool", "--unlimited"]
+
+    yield imported_bugtool  # provide the bugtool to the test function
+
+    # Cleanup the bugtool data dict after each test as tests may modify it:
+    imported_bugtool.data = {}
+    sys.argv = ["xen-bugtool", "--unlimited"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -88,3 +88,89 @@ def bugtool(imported_bugtool):
     # Cleanup the bugtool data dict after each test as tests may modify it:
     imported_bugtool.data = {}
     sys.argv = ["xen-bugtool", "--unlimited"]
+
+
+@pytest.fixture(scope="function")
+def in_tmpdir(tmpdir):
+    """
+    Run each test function in it's own temporary directory
+
+    This fixture warps pytest's built-in tmpdir fixture with a chdir()
+    to the tmpdir and a check for leftover files after the test returns.
+
+    Usage in a test function:
+
+    @pytest.usefixtures("in_tmpdir")
+    def test_foo(other_fixtures):
+        # ... test code that runs with the tmpdir as its working directory ...
+
+    # If the test function wants to use the in_tmpdir variable:
+    def test_foo(in_tmpdir):
+        in_tmpdir.mkdir("subdir").join("filename").write("content_for_testing")
+        # code under test, that runs with the tmpdir as its working directory:
+        with open("subdir/filename") as f:
+            assert f.read() == "content_for_testing"
+
+    Documentation on the wrapped tmpdir fixture:
+    https://docs.pytest.org/en/6.2.x/tmpdir.html#the-tmpdir-fixture
+    """
+
+    # Get the current directory:
+    curdir = os.getcwd()
+
+    # Change to the temporary directory:
+    os.chdir(str(tmpdir))
+
+    # Run the test:
+    yield tmpdir  # provide the fixture value to the pytest test function
+
+    # Change back to the original directory:
+    os.chdir(curdir)
+
+    # upon return, the tmpdir fixture will cleanup the temporary directory
+
+
+@pytest.fixture(scope="function")
+def bugtool_log(in_tmpdir, bugtool):
+    """Like in_tmpdir and check that no logs are left in XEN_BUGTOOL_LOG"""
+
+    in_tmpdir.mkdir("tmp")  # Create a tmp directory for use by test cases
+
+    in_tmpdir.join(bugtool.XEN_BUGTOOL_LOG).write("")  # create the log file
+
+    # Run the test:
+    yield bugtool  # provide the bugtool to the test function
+
+    log = in_tmpdir.join(bugtool.XEN_BUGTOOL_LOG).read()  # read the log file
+    if log:  # pragma: no cover
+        print("Content of " + bugtool.XEN_BUGTOOL_LOG + ":" + log, file=sys.stderr)
+        pytest.fail("Code under test left logs in " + bugtool.XEN_BUGTOOL_LOG)
+
+    # Cleanup the temporary directory to prepare to check leftover files:
+    os.remove(bugtool.XEN_BUGTOOL_LOG)
+    shutil.rmtree("tmp")
+
+    # Check for files that the code under test might have left:
+    files = in_tmpdir.listdir()
+    if files:  # pragma: no cover
+        print("Files left in temporary working dir:", files, file=sys.stderr)
+        pytest.fail("Code under test left files in the its working directory")
+
+    # upon return, the in_tmpdir switches back to the original directory
+
+
+@pytest.fixture(scope="function")
+def isolated_bugtool(bugtool_log):
+    """
+    Like `bugtool_log` and make the temporary working directory read-only
+    to prevent creating files in it
+    """
+
+    # Make the current cwd (a temporary directory) read-only:
+    os.chmod(".", 0o555)
+
+    yield bugtool_log  # runs the test function in the read-only directory
+
+    os.chmod(".", 0o777)  # restore write permissions (for cleanup)
+
+    # upon return, bugtool_log continues with its cleanup

--- a/tests/unit/test_dir_list.py
+++ b/tests/unit/test_dir_list.py
@@ -1,0 +1,35 @@
+"""tests/unit/test_dir_list.py: Unit-Test bugtool.dir_list(cap, path_list)"""
+
+
+def test_dir_list(bugtool):
+    """Test the bugtool function dir_list(cap, path_list) to perform as expected"""
+
+    # Arguments for the positive test:
+    cap = bugtool.CAP_XENSERVER_CONFIG
+    path_list = [__file__.replace(".", "*")]
+
+    # Assert that mis-matching cap causes no output in bugtool.data:
+    bugtool.entries = [bugtool.CAP_DISK_INFO, cap, bugtool.CAP_PAM]
+    bugtool.dir_list(cap=bugtool.CAP_XENSERVER_LOGS, path_list=path_list)
+    assert bugtool.data == {}
+
+    # Assert that mis-matching path_list results in no bugtool.data:
+    bugtool.dir_list(cap=cap, path_list=[__file__ + "*notexist*"])
+    assert bugtool.data == {}
+
+    # Assert matching cap and path_list produces expected_data
+    bugtool.dir_list(cap=cap, path_list=path_list)
+
+    expected_data = {
+        "ls -l "
+        + __file__: {
+            "filter": None,
+            "cap": "xenserver-config",
+            "cmd_args": [
+                "ls",
+                "-l",
+                __file__,
+            ],
+        }
+    }
+    assert bugtool.data == expected_data

--- a/tests/unit/test_filter_xapi_clusterd_db.py
+++ b/tests/unit/test_filter_xapi_clusterd_db.py
@@ -1,0 +1,314 @@
+"""tests/unit/test_filter_xapi_clusterd_db.py: Test filter_xapi_clusterd_db()
+
+TODO:
+
+This test must be made to fail to cover two current bugtool bugs
+because the filter_xapi_clusterd_db() function is not implemented correctly.
+
+Current Bugs in filter_xapi_clusterd_db():
+
+1.  The filter must replace "token": "secret-token", with "token": "REMOVED"
+2.  The filter must also work if the "pems" key is missing
+3.  The filter must also work if "pems.blobs" is missing
+4.  The filter must also work if "authkey" is missing
+    Points 2-4 above apply to "cluster_config" and "old_cluster_config".
+
+Explanation for PASS tests: Those are the cases that are currently passing.
+Explanation for XFAIL tests: Those are the cases that are currently failing
+and must be fixed:
+- They use the pytest.mark.xfail decorator to mark the tests as expected to fail.
+- They are marked with "XFAIL" in the test output.
+- The pytest.mark.xfail decorator must be removed after the bug is fixed
+  to ensure the test is run and passes in the future.
+
+TODO START:
+
+1.  Add additional XFAIL tests, one for each, which fail on the cases above
+[DONE]
+
+2.  Add additional PASS test:
+    The filter must also work if "cluster_config" or/and "old_cluster_config"
+    are missing.
+[DONE]
+
+3.  Add additional PASS test:
+    The filter must also work if the "token" key is missing.
+[DONE]
+
+4.  The changes are added as additional commits and pushed.
+    The individual sub-tests must be shown failing on each the cases above.
+
+5.  The filter must be updated to handle these cases.
+
+6.  The PR is then pushed again and then pass.
+
+    Changes to the test should only be needed if e.g. logging was added
+    to test the logging output.
+
+Ideally, if there is capacity for it, pre-commit hooks should run on every
+commit to ensure that each works without any errors
+
+This can be done by running:
+    git rebase -x 'pre-commit run --from-ref HEAD~ --to-ref HEAD' HEAD~1
+[DONE] (for all commits in this PR)
+
+Replace the `1` with the number of commits to run the pre-commit hooks on.
+This opens an editor with the commits and checks to run on them. When it,
+by mistake contains one or more commits that are not only the ones that
+are in the current PR, remove them all commits from the editor and save
+the file. In this case `git rebase` will do nothing and no commits are changed.
+
+With all of these TODO done, step-by-step, in order, work will be complete.
+
+Tip:
+
+Run `pip install pre-commit` and then use `pre-commit run`
+to check the code and run all unit tests and checks before committing
+and pushing the code.
+
+pre-commit run will:
+- remove trailing whitespace from the code for uniformity
+- fix the code style of the tests with black and of xen-bugtool with darker
+- run unit tests with coverage and check the coverage on the changed lines
+
+If you run `pre-commit install`, it will run on every commit in your own clone.
+
+TODO END.
+
+"""
+
+import json
+import os
+
+import pytest
+
+
+# Minimal example of a xapi-clusterd/db file, with sensitive data
+# BUG: The new cluster_config has no "pems" key, so the filter has to be updated
+# to handle this case, pass data and still filter the "old_cluster_config" key.
+ORIGINAL = r"""
+{
+    "token": "secret-token",
+    "cluster_config": {
+        "pems": {
+            "blobs": "secret-blob"
+        },
+        "authkey": "secret-key"
+    },
+    "old_cluster_config": {
+        "pems": {
+            "blobs": "secret-blob"
+        },
+        "authkey": "secret-key"
+    },
+    "max_config_version": 1
+}"""
+
+# Same as original, but with passwords and private data replaced by: "REMOVED"
+# BUG: "secret-token" has to be replaced by "REMOVED"
+EXPECTED = r"""{
+    "token": "secret-token",
+    "cluster_config": {
+        "pems": {
+            "blobs": "REMOVED"
+        },
+        "authkey": "REMOVED"
+    },
+    "old_cluster_config": {
+        "pems": {
+            "blobs": "REMOVED"
+        },
+        "authkey": "REMOVED"
+    },
+    "max_config_version": 1
+}"""
+
+
+def assert_filter_xapi_clusterd_db(bugtool, original, expected):
+    """Assert that filter_xapi_clusterd_db() replaces sensitive strings"""
+
+    # -------------------------------------------------------------------------
+    # Common setup:
+    # -------------
+    # - Define the file name of the temporary xAPI clusterd db.
+    #
+    # Notes:
+    # ------
+    # - To allow for checking of logged errors, the bugtool_log fixture will be used.
+    #
+    # - After the test function returns, the bugtool_log fixture checks the log:
+    #
+    #   The bugtool_log fixture will raise an error if the xen-bugtool.log file
+    #   as unexpected content, and the error message will be printed to stderr.
+    #
+    #   This way, cases where errors logged by the code under test can be checked.
+    #
+    temporary_test_clusterd_db = "tmp/xapi_clusterd_db.json"
+    # -------------------------------------------------------------------------
+
+    # -------------------------------------------------------------------------
+    # Prepare:
+    # --------
+    #
+    # 1. Write the original xapi-clusterd/db contents to the temporary file
+    # 2. Patch the bugtool module to use the temporary file for reading the db
+    #
+    with open(temporary_test_clusterd_db, "w") as f:
+        f.write(original)
+
+    bugtool.XAPI_CLUSTERD = temporary_test_clusterd_db
+    # -------------------------------------------------------------------------
+
+    # -------------------------------------------------------------------------
+    # Act:
+    # ----
+    #
+    # -> Call the  filter function
+    #
+    filtered = bugtool.filter_xapi_clusterd_db("_")
+    # -------------------------------------------------------------------------
+
+    # -------------------------------------------------------------------------
+    # Assert:
+    # -------
+    #
+    # -> Compare the filtered output with the expected output
+    #
+    try:
+        assert json.loads(filtered) == json.loads(expected)
+    except ValueError:  # For invalid json (to test handing of corrupted db)
+        assert filtered == expected
+
+    os.remove(temporary_test_clusterd_db)
+    # -------------------------------------------------------------------------
+
+
+def test_pems_blobs(isolated_bugtool):
+    """Assert that filter_xapi_clusterd_db() replaces pems.blobs strings"""
+    assert_filter_xapi_clusterd_db(isolated_bugtool, ORIGINAL, EXPECTED)
+
+
+# CA-358870: filter_xapi_clusterd_db: remove token from the report
+@pytest.mark.xfail(reason="bugtool currently fails to remove the token")
+def test_remove_token(isolated_bugtool):
+    """CA-358870: Assert that filter_xapi_clusterd_db() removes the token"""
+
+    # Load the expected output and remove the token from it
+    expected = json.loads(EXPECTED)
+    expected["token"] = "REMOVED"
+    expected_json = json.dumps(expected)
+
+    assert_filter_xapi_clusterd_db(isolated_bugtool, ORIGINAL, expected_json)
+
+
+@pytest.mark.xfail(reason="bugtool currently fails to handle missing authkey")
+def test_no_authkey(isolated_bugtool):
+    """Assert that filter_xapi_clusterd_db() handles missing authkey"""
+
+    def remove_authkey(json_data):
+        """Remove the authkey from the clusterd db"""
+        data = json.loads(json_data)
+        # sourcery skip: no-loop-in-tests
+        for key in ["cluster_config", "old_cluster_config"]:
+            if "authkey" in data[key]:
+                data[key].pop("authkey")
+        return json.dumps(data)
+
+    assert_filter_xapi_clusterd_db(
+        isolated_bugtool,
+        remove_authkey(ORIGINAL),
+        remove_authkey(EXPECTED),
+    )
+
+
+@pytest.mark.xfail(reason="bugtool currently fails to handle missing pems")
+def test_no_pems(isolated_bugtool):
+    """Assert that filter_xapi_clusterd_db() handles missing pems"""
+
+    def remove_pems(json_data):
+        """Remove the pems key from the clusterd db"""
+        data = json.loads(json_data)
+        # sourcery skip: no-loop-in-tests
+        for key in ["cluster_config", "old_cluster_config"]:
+            if "pems" in data[key]:
+                data[key].pop("pems")
+        return json.dumps(data)
+
+    assert_filter_xapi_clusterd_db(
+        isolated_bugtool,
+        remove_pems(ORIGINAL),
+        remove_pems(EXPECTED),
+    )
+
+
+@pytest.mark.xfail(reason="bugtool currently fails to handle missing pems.blobs")
+def test_no_blobs(isolated_bugtool):
+    """Assert that filter_xapi_clusterd_db() handles missing blobs"""
+
+    def remove_blobs(json_data):
+        """Remove the pems.blobs key from the clusterd db"""
+        data = json.loads(json_data)
+        # sourcery skip: no-loop-in-tests
+        for key in ["cluster_config", "old_cluster_config"]:
+            if "pems" in data[key] and "blobs" in data[key]["pems"]:
+                data[key]["pems"].pop("blobs")
+        return json.dumps(data)
+
+    assert_filter_xapi_clusterd_db(
+        isolated_bugtool,
+        remove_blobs(ORIGINAL),
+        remove_blobs(EXPECTED),
+    )
+
+
+def test_no_config(isolated_bugtool):
+    """Assert that filter_xapi_clusterd_db() handles missing cluster_configs"""
+
+    def remove_cluster_configs(json_data):
+        """Remove the {,old_}cluster_configs keys from the clusterd db"""
+        data = json.loads(json_data)
+        data.pop("cluster_config")
+        data.pop("old_cluster_config")
+        return json.dumps(data)
+
+    assert_filter_xapi_clusterd_db(
+        isolated_bugtool,
+        remove_cluster_configs(ORIGINAL),
+        remove_cluster_configs(EXPECTED),
+    )
+
+
+def test_no_token(isolated_bugtool):
+    """Assert that filter_xapi_clusterd_db() handles missing token"""
+
+    def remove_cluster_token(json_data):
+        """Remove the token key from the clusterd db"""
+        data = json.loads(json_data)
+        data.pop("token")
+        return json.dumps(data)
+
+    assert_filter_xapi_clusterd_db(
+        isolated_bugtool,
+        remove_cluster_token(ORIGINAL),
+        remove_cluster_token(EXPECTED),
+    )
+
+
+def test_no_database(isolated_bugtool):
+    """Assert that filter_xapi_clusterd_db() handles missing token"""
+
+    isolated_bugtool.XAPI_CLUSTERD = "/does/not/exist"
+    assert isolated_bugtool.filter_xapi_clusterd_db("_") == ""
+
+
+def test_invalid_db(isolated_bugtool, capsys):
+    """Assert how filter_xapi_clusterd_db() handles a corrupted db"""
+
+    # The filter must handle invalid json and return the expected output,
+    # which no output, as the db is not readable and the filter should
+    # return an empty string (in an ideal world, it would return an error message)
+    assert_filter_xapi_clusterd_db(isolated_bugtool, "invalid json", "")
+
+    with capsys.disabled():
+        stdout = capsys.readouterr().out
+        assert stdout == ""

--- a/tests/unit/test_filter_xapi_clusterd_db.py
+++ b/tests/unit/test_filter_xapi_clusterd_db.py
@@ -107,7 +107,7 @@ ORIGINAL = r"""
 # Same as original, but with passwords and private data replaced by: "REMOVED"
 # BUG: "secret-token" has to be replaced by "REMOVED"
 EXPECTED = r"""{
-    "token": "secret-token",
+    "token": "REMOVED",
     "cluster_config": {
         "pems": {
             "blobs": "REMOVED"
@@ -189,7 +189,6 @@ def test_pems_blobs(isolated_bugtool):
 
 
 # CA-358870: filter_xapi_clusterd_db: remove token from the report
-@pytest.mark.xfail(reason="bugtool currently fails to remove the token")
 def test_remove_token(isolated_bugtool):
     """CA-358870: Assert that filter_xapi_clusterd_db() removes the token"""
 

--- a/tests/unit/test_filter_xapi_clusterd_db.py
+++ b/tests/unit/test_filter_xapi_clusterd_db.py
@@ -80,8 +80,6 @@ TODO END.
 import json
 import os
 
-import pytest
-
 
 # Minimal example of a xapi-clusterd/db file, with sensitive data
 # BUG: The new cluster_config has no "pems" key, so the filter has to be updated
@@ -200,7 +198,6 @@ def test_remove_token(isolated_bugtool):
     assert_filter_xapi_clusterd_db(isolated_bugtool, ORIGINAL, expected_json)
 
 
-@pytest.mark.xfail(reason="bugtool currently fails to handle missing authkey")
 def test_no_authkey(isolated_bugtool):
     """Assert that filter_xapi_clusterd_db() handles missing authkey"""
 
@@ -220,7 +217,6 @@ def test_no_authkey(isolated_bugtool):
     )
 
 
-@pytest.mark.xfail(reason="bugtool currently fails to handle missing pems")
 def test_no_pems(isolated_bugtool):
     """Assert that filter_xapi_clusterd_db() handles missing pems"""
 
@@ -240,7 +236,6 @@ def test_no_pems(isolated_bugtool):
     )
 
 
-@pytest.mark.xfail(reason="bugtool currently fails to handle missing pems.blobs")
 def test_no_blobs(isolated_bugtool):
     """Assert that filter_xapi_clusterd_db() handles missing blobs"""
 

--- a/tests/unit/test_fs_funcs.py
+++ b/tests/unit/test_fs_funcs.py
@@ -1,0 +1,13 @@
+"""Regression tests for bugtool helper functions like get_recent_logs()"""
+
+
+def test_read_inventory(bugtool, dom0_template):
+    """Assert readKeyValueFile() reading the a xensource inventory file"""
+
+    inventory = bugtool.readKeyValueFile(dom0_template + bugtool.XENSOURCE_INVENTORY)
+    assert inventory["PRODUCT_VERSION"] == "8.3.0"
+
+
+def test_disk_list(bugtool):
+    """Assert that the return value of disk_list() contains sda or nvme0n1"""
+    assert "sda" in bugtool.disk_list() or "nvme0n1" in bugtool.disk_list()

--- a/tests/unit/test_load_plugins.py
+++ b/tests/unit/test_load_plugins.py
@@ -1,0 +1,56 @@
+"""Regression tests for bugtool.load_plugins()"""
+
+
+def test_load_plugins(bugtool, dom0_template):
+    """Assert () returning arrays of the  in the dom0-template"""
+
+    # Use the plugins found in the dom0_template "/etc/xensource/bugtool":
+    bugtool.PLUGIN_DIR = dom0_template + "/etc/xensource/bugtool"
+    # Only process the mock bugtool plugin:
+    bugtool.entries = ["mock"]
+    # Load the mock plugin:
+    bugtool.load_plugins(just_capabilities=False)
+    # Assert the set of properties of the created mock capability:
+    assert bugtool.caps["mock"] == (
+        "mock",
+        "yes",
+        -1,
+        16384,
+        -1,
+        60,
+        "text/plain",
+        True,
+        False,
+        9,
+    )
+    # Assert the size of the files of the created mock inventory entry:
+    assert bugtool.cap_sizes["mock"] > 0  # /etc/passwd should have content
+    # Assert the entries added to the bugtool.data dict:
+    assert bugtool.data == {
+        "ls -l /etc": {
+            "cap": "mock",
+            "cmd_args": ["ls", "-l", "/etc"],
+            "filter": None,
+        },
+        "/etc/passwd": {
+            "cap": "mock",
+            "filename": "/etc/passwd",
+        },
+        "/etc/group": {
+            "cap": "mock",
+            "filename": "/etc/group",
+        },
+        "/proc/self/status": {
+            "cap": "mock",
+            "filename": "/proc/self/status",
+        },
+        "/proc/sys/fs/epoll/max_user_watches": {
+            "cap": "mock",
+            "filename": "/proc/sys/fs/epoll/max_user_watches",
+        },
+        "proc_version": {
+            "cap": "mock",
+            "cmd_args": "cat /proc/version",
+            "filter": None,
+        },
+    }

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,245 @@
+"""pytest module for unit-testing xen-bugtool's main() function"""
+import logging
+import os
+import sys
+import tarfile
+import zipfile
+
+import pytest
+
+from . import test_xapidb_filter
+from .test_output import assert_valid_inventory_schema, parse
+
+
+yes_to_all_warning = """\
+Warning: '--yestoall' argument provided, will not prompt for individual files.
+"""
+bugtool_banner = """
+This application will collate the Xen dmesg output, details of the
+hardware configuration of your machine, information about the build of
+Xen that you are using, plus, if you allow it, various logs.
+
+The collated information will be saved as a .zip for archiving or
+sending to a Technical Support Representative.
+
+The logs may contain private information, and if you are at all
+worried about that, you should exit now, or you should explicitly
+exclude those logs from the archive.
+
+
+"""
+
+
+def patch_bugtool(bugtool, mocker, dom0_template, report_name, tmp_path):
+    """Patch a bugtool module with mocks and configurations to execute main()
+
+    :param bugtool: The imported bugtool module object to be patched.
+    :param mocker: The mocker object for mocking functions and attributes.
+    :param dom0_template: The path to the dom0 template directory.
+    :param report_name: The basename of the bug-report file and it's subdir.
+    :param tmp_path: The temporary path for storing files.
+    """
+
+    # Mock os.getuid to simulate the root user:
+    mocker.patch("os.getuid", return_value=0)
+
+    # Turn the timestamp in the logs into a fixed string:
+    mocker.patch("time.strftime", return_value="time.strftime")
+
+    # Set the name of the bug-report file and the subdirectory in it:
+    os.environ["XENRT_BUGTOOL_BASENAME"] = report_name
+
+    # Mock the location of the several path to be in our dom0 template dir:
+    bugtool.VAR_LOG_DIR = dom0_template + "/var"
+    bugtool.XENSOURCE_INVENTORY = dom0_template + "/etc/xensource-inventory"
+    bugtool.SYSTEMD_CONF_DIR = dom0_template + "/etc/systemd"
+    bugtool.BIN_STATIC_VDIS = dom0_template + "/opt/xensource/bin/static-vdis"
+
+    # These do not have to be exact mocks, they just have to return success:
+    bugtool.HA_QUERY_LIVESET = dom0_template + "/usr/sbin/mdadm"
+    bugtool.XENSTORE_LS = dom0_template + "/usr/sbin/xenstore-ls"
+    bugtool.PLUGIN_DIR = dom0_template + "/etc/xensource/bugtool"
+    bugtool.RPM = dom0_template + "/usr/sbin/multipathd"
+    tmp = tmp_path.as_posix()
+
+    # Write a simple xAPI DB for bugtool to filter and check its output later
+    xensource_db_conf = tmp + "/db.conf"
+    xen_api_state_db = tmp + "/xen_api_state.db"
+    with open(xen_api_state_db, "w") as db_state:
+        db_state.write(test_xapidb_filter.original)
+    with open(xensource_db_conf, "w") as db_conf:
+        db_conf.write("[" + xen_api_state_db + "]")
+    bugtool.DB_CONF = xensource_db_conf
+
+    # To cover the the code resulting from inputting "n", we need to mock input:
+    def input(prompt):
+        return "n" if "/proc" in prompt else "y"
+
+    bugtool.raw_input = input
+
+    entries = [
+        "xenserver-config",
+        "xenserver-databases",
+        "mock",
+        "unknown",
+    ]
+    sys.argv.append("--entries=" + ",".join(entries))
+    bugtool.BUG_DIR = tmp
+
+
+def check_output(bugtool, captured, tmp_path, filename, filetype):
+    # sourcery skip: path-read
+    """Check the stdout, db and inventory output of a bugtool's main() function
+
+    This function checks the output of the bugtool application to ensure that
+    it matches the expected output. It compares the captured output with the
+    expected output and performs various assertions to validate the output.
+
+    It extracts the output files from the archive and checks that the xAPI db
+    and the inventory.xml.
+
+    Tested output:
+    - The start and end of the collected bugtool messages from captured.out
+    - The inventory.xml file is checked to be validated using its XML schema.
+    - The xapi-db.xml is checked to have secrets filtered using a dummy xapi db
+
+    :param bugtool: The patched bugtool module object to be executed
+    :param captured: The captured stdout output from running the bugtool main()
+    :param tmp_path: The temporary path where the output files are stored.
+    :param filename: The name of the bug-report output archive.
+    :param filetype: The type of the output file (zip, tar, or tar.bz2)
+
+    :raises AssertionError: When the output does not match the expected output.
+    """
+
+    out_begin = bugtool_banner.replace("zip", filetype)
+    p = "[time.strftime]  "
+
+    if bugtool.ProcOutput.debug:
+        out_begin += p + "Starting 'mdadm --detail --scan'\n"
+
+    fd = "--outfd=" in " ".join(sys.argv)
+    if not fd:
+        out_begin += p + "Creating output file\n"
+
+    out_begin += p + "Running commands to collect data\n"
+    # Provides a nicely formatted diff (unlike str.startswith()) on assertions:
+    assert captured.out[: len(out_begin)] == out_begin
+
+    if bugtool.ProcOutput.debug:
+        assert p + "Starting '%s list'\n" % bugtool.BIN_STATIC_VDIS in captured.out
+        for ls in ("/opt/xensource", "/etc/xensource/static-vdis"):
+            assert p + "Starting 'ls -lR %s'\n" % ls in captured.out
+
+    if not fd:
+        archive = "tarball" if filetype.startswith("tar") else "archive"
+        success = "Writing %s %s successful.\n" % (archive, filename)
+        assert success in captured.out
+
+    # Extract the created output file into the tmp_path
+    if filetype == "zip":
+        zipfile.ZipFile(filename).extractall(tmp_path)
+    elif filetype == "tar":
+        tarfile.TarFile.open(filename).extractall(tmp_path)
+    elif filetype == "tar.bz2":
+        tarfile.TarFile.open(filename, "r:bz2").extractall(tmp_path)
+
+    output_directory = filename.replace(".%s" % filetype, "/")
+
+    # Assert that the captured dummy Xen-API database to filtered as expected:
+    with open(output_directory + "/xapi-db.xml") as xen_api_db:
+        data = xen_api_db.read()
+    test_xapidb_filter.assert_xml_str_equiv(data, test_xapidb_filter.expected)
+
+    # Assert that the captured output from the fake xenstore-ls is as expected:
+    with open(output_directory + "/xenstore-ls-f.out") as xenstore_ls_f:
+        d = xenstore_ls_f.read()
+    assert d == "/local/domain/1/data/set_clipboard = <filtered for security>\n"
+
+    # Assertion check of the output files is missing an inventory entry:
+    # Do this check in a future test which runs
+    assert_valid_inventory_schema(parse(output_directory + "inventory.xml"))
+
+
+def assert_valid_inventory(bugtool, args, cap, tmp_path, base_path, filetype):
+    """Run the bugtool module object's main() function and check its output
+
+    This function runs the patched bugtool module object and asserts that its
+    output matches the expected output.
+
+    :param bugtool: The patched bugtool module object to be executed
+    :param args: Additional arguments to set for running the bugtool's main()
+    :param cap: cap pytest fixture to validate the bugtool stdout
+    :param tmp_path: The temporary path where the output files are stored.
+    :param base_path: The base directory and base name of the output file.
+    :param filetype: The type of the output file (zip, tar, or tar.bz2)
+
+    :raises AssertionError: When the output does not match the expected output.
+    """
+    sys.argv.extend(args)
+
+    assert bugtool.main() == 0
+    filename = base_path + "." + filetype
+    with cap.disabled():
+        check_output(bugtool, cap.readouterr(), tmp_path, filename, filetype)
+
+
+@pytest.fixture(scope="function")
+def patched_bugtool(bugtool, mocker, dom0_template, tmp_path):
+    """PyTest fixture providing a patched bugtool module with mocks and
+    configurations to execute its main() from a unprivileged unit test process
+    on a regular Linux host, with test data from the framework's dom0 template.
+
+    :param bugtool: The imported bugtool module object to be patched.
+    :param mocker: The mocker object for mocking functions and attributes.
+    :param dom0_template: The path to the dom0 template directory.
+    :param tmp_path: The temporary path for storing files.
+    """
+    patch_bugtool(bugtool, mocker, dom0_template, "main_mocked", tmp_path)
+
+    base_path = tmp_path / os.environ["XENRT_BUGTOOL_BASENAME"]
+    return bugtool, base_path.as_posix(), tmp_path.as_posix()
+
+
+def test_main_func_output_to_zipfile(patched_bugtool, capfd):
+    """Assert creating a zipfile creates a zipfile with a valid XML inventory
+
+    :param patched_bugtool: The patched bugtool module object to be tested
+    :param capfd: The capfd pytest fixture capturing stdout and stderr fds
+    """
+
+    bugtool, base_path, tmp_path = patched_bugtool
+    filetype = "zip"
+    args = ["--output=" + filetype]
+    assert_valid_inventory(bugtool, args, capfd, tmp_path, base_path, filetype)
+
+
+def test_main_func_output_to_tarfd(patched_bugtool, capfd):
+    """Assert writing a tar fd creates a tarball with a valid XML inventory
+
+    :param patched_bugtool: The patched bugtool module object to be tested
+    :param capfd: The capfd pytest fixture capturing stdout and stderr fds
+    """
+
+    bugtool, base_path, tmp_path = patched_bugtool
+    filetype = "tar"
+    filename = base_path + "." + filetype
+    # Test writing the tarball to an opened file descriptor:
+    fd = os.open(filename, os.O_CREAT | os.O_WRONLY)
+    args = ["--outfd=%s" % fd, "--output=tar"]
+    bugtool.ProcOutput.debug = False
+    assert_valid_inventory(bugtool, args, capfd, tmp_path, base_path, filetype)
+
+
+def test_main_func_output_to_tarbz2(patched_bugtool, capfd):
+    """Assert creating a tar.bz2 creates a tarball with a valid XML inventory
+
+    :param patched_bugtool: The patched bugtool module object to be tested
+    :param capfd: The capfd pytest fixture capturing stdout and stderr fds
+    """
+
+    bugtool, base_path, tmp_path = patched_bugtool
+    filetype = "tar.bz2"
+    args = ["--output=" + filetype]
+    bugtool.ProcOutput.debug = False
+    assert_valid_inventory(bugtool, args, capfd, tmp_path, base_path, filetype)

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,0 +1,136 @@
+"""Unit tests for bugtool core functions creating minimal output archives"""
+import os
+import tarfile
+import zipfile
+
+from lxml.etree import XMLSchema, parse  # pytype: disable=import-error
+
+
+def assert_valid_inventory_schema(inventory_tree):
+    """Assert that the passed inventory validates against the inventory schema"""
+
+    with open(os.getcwd() + "/tests/integration/inventory.xsd") as xml_schema:
+        XMLSchema(parse(xml_schema)).assertValid(inventory_tree)
+
+
+def assert_mock_bugtool_plugin_output(temporary_directory, subdir, names):
+    """Assertion check of the output files from the mock bugtool plugin"""
+
+    # Assert the list of file names in the status report archive:
+    expected_names = [
+        subdir + "/etc/group",
+        subdir + "/etc/passwd.tar",
+        subdir + "/inventory.xml",
+        subdir + "/ls-l-%etc.out",
+        subdir + "/proc/self/status",
+        subdir + "/proc/sys/fs/epoll/max_user_watches",
+        subdir + "/proc_version.out",
+    ]
+    assert sorted(names) == expected_names
+
+    extracted = "%s/%s/" % (temporary_directory, subdir)
+
+    # Will be refactored to be more easy in a separate commit soon:
+    assert_valid_inventory_schema(parse(extracted + "inventory.xml"))
+    with open(extracted + "proc_version.out") as proc_version:
+        assert proc_version.read()[:14] == "Linux version "
+    with open(extracted + "ls-l-%etc.out") as etc:
+        assert etc.read()[:6] == "total "
+    with open(extracted + "proc/self/status") as status:
+        assert status.read()[:5] == "Name:"
+    with open(extracted + "proc/sys/fs/epoll/max_user_watches") as max_user_watches:
+        assert int(max_user_watches.read()) > 0
+    with open(extracted + "etc/group") as group:
+        assert group.readline() == "root:x:0:\n"
+
+    # Check the contents of the sub-archive "etc/passwd.tar":
+    with tarfile.TarFile(extracted + "etc/passwd.tar") as tar:
+        assert tar.getnames() == [subdir + "/etc/passwd"]
+        # TarFile.extractfile() does not support context managers on Python2:
+        passwd = tar.extractfile(subdir + "/etc/passwd")
+        assert passwd
+        assert passwd.readline() == b"root:x:0:0:root:/root:/bin/bash\n"
+        passwd.close()
+
+
+def minimal_bugtool(bugtool, dom0_template, archive, subdir, mocker):
+    """Load the plugins from the template and include the generated inventory"""
+
+    mocker.patch("xen-bugtool.time.strftime", return_value="time.strftime")
+    # Load the mock plugin from dom0_template and process the plugin's caps:
+    bugtool.PLUGIN_DIR = dom0_template + "/etc/xensource/bugtool"
+    bugtool.entries = ["mock"]
+    archive.declare_subarchive("/etc/passwd", subdir + "/etc/passwd.tar")
+    # For code coverage: This sub-archive will not be created as it has no file
+    archive.declare_subarchive("/not/existing", subdir + "/not_created.tar")
+    bugtool.load_plugins(just_capabilities=False)
+    # Mock the 2nd argument of the ls -l /etc to collect it using dom0_template:
+    bugtool.data["ls -l /etc"]["cmd_args"][2] = dom0_template + "/etc"
+    bugtool.collect_data(subdir, archive)
+    bugtool.include_inventory(archive, subdir)
+    archive.close()
+
+
+def assert_minimal_bugtool(bugtool, state_archive, dom0_template, cap):
+    """Check the output of the bugtool unit test.
+    :param bugtool: The tested bugtool module object
+    :param state_archive: The tested bugtool output archive.
+    :param dom0_template: The dom0 template used in the unit test.
+    :param cap: The output (stdout, stderr) pytest captured from the unit test.
+
+    :raises AssertionError: When the output does not match the expected output.
+    """
+    captured_stdout = cap.readouterr().out
+
+    # When debug output from ProcOutput is enabled, "Starting" is printed:
+    if bugtool.ProcOutput.debug:
+        version = "cat /proc/version"
+        etc_dir = "ls -l %s/etc" % dom0_template
+        for msg in [version, etc_dir]:
+            assert "[time.strftime]  Starting '%s'\n" % msg in captured_stdout
+
+    filetype = "tarball" if ".tar" in state_archive.filename else "archive"
+    written = "Writing %s %s successful.\n" % (filetype, state_archive.filename)
+    assert captured_stdout[-len(written) :] == written
+
+
+def test_tar_output(bugtool, tmp_path, dom0_template, mocker, capfd):
+    """Assert that a bugtool unit test creates a valid minimal tar archive"""
+
+    bugtool.BUG_DIR = tmp_path
+    archive = bugtool.TarOutput("tarball", "tar", -1)
+    subdir = "tar_dir"
+
+    # Create a minimal bugtool output archive to test core functions:
+    bugtool.ProcOutput.debug = True
+    minimal_bugtool(bugtool, dom0_template, archive, subdir, mocker)
+
+    with capfd.disabled():
+        assert_minimal_bugtool(bugtool, archive, dom0_template, capfd)
+
+    # Check the TarFile contents
+    tmp = tmp_path.as_posix()
+    with tarfile.TarFile(tmp + "/tarball.tar") as tar:
+        tar.extractall(tmp)
+        assert_mock_bugtool_plugin_output(tmp, subdir, tar.getnames())
+
+
+def test_zip_output(bugtool, tmp_path, dom0_template, mocker, capfd):
+    """Assert that a bugtool unit test creates a valid minimal zip archive"""
+
+    bugtool.BUG_DIR = tmp_path
+    archive = bugtool.ZipOutput("zipfile")
+    subdir = "zip_dir"
+
+    # Create a minimal bugtool output archive to test core functions:
+    bugtool.ProcOutput.debug = True
+    minimal_bugtool(bugtool, dom0_template, archive, subdir, mocker)
+
+    with capfd.disabled():
+        assert_minimal_bugtool(bugtool, archive, dom0_template, capfd)
+
+    # Check the ZipFile contents
+    tmp = tmp_path.as_posix()
+    with zipfile.ZipFile(tmp + "/zipfile.zip") as zip:
+        zip.extractall(tmp)
+        assert_mock_bugtool_plugin_output(tmp, subdir, zip.namelist())

--- a/tests/unit/test_process_output.modules
+++ b/tests/unit/test_process_output.modules
@@ -1,0 +1,3 @@
+tcp_diag 16384 0 - Live 0xffffffffc05c0000
+udp_diag 16384 0 - Live 0xffffffffc059c000
+inet_diag 24576 2 tcp_diag,udp_diag, Live 0xffffffffc0533000

--- a/tests/unit/test_process_output.py
+++ b/tests/unit/test_process_output.py
@@ -1,0 +1,24 @@
+"""Regression tests for the bugtool helper function mdadm_arrays()"""
+
+
+def test_mdadm_arrays(bugtool, dom0_template):
+    """Assert mdadm_arrays() to return data of the dom0-template/usr/sbin/mdadm"""
+
+    bugtool.MDADM = dom0_template + "/usr/sbin/mdadm"
+    assert list(bugtool.mdadm_arrays()) == ["/dev/md0", "/dev/md1"]
+
+
+def test_module_info(bugtool, dom0_template):
+    """Assert module_info() to return module names dom0-template/usr/sbin/modinfo"""
+
+    bugtool.PROC_MODULES = __file__.replace(".py", ".modules")
+    bugtool.MODINFO = dom0_template + "/usr/sbin/modinfo"
+    output = bugtool.module_info(bugtool.CAP_KERNEL_INFO)
+    assert output == "modinfo for tcp_diag\nmodinfo for udp_diag\nmodinfo for inet_diag\n"
+
+
+def test_multipathd_topology(bugtool, dom0_template):
+    """Assert multipathd_topology() returning the output of the mock multipathd tool"""
+
+    bugtool.MULTIPATHD = dom0_template + "/usr/sbin/multipathd"
+    assert bugtool.multipathd_topology(bugtool.CAP_MULTIPATH) == "multipathd-k"

--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -1,0 +1,95 @@
+"""Ensure that the xen-bugtool.DBFilter() filters the XAPI DB properly"""
+import os
+import sys
+from xml.dom.minidom import parseString
+from xml.etree.ElementTree import fromstring
+
+
+testdir = os.path.dirname(__file__)
+original = r"""<?xml version="1.0" ?>
+<root>
+    <table name="secret">
+        <row id="1">
+            <value>mysecretpassword</value>
+        </row>
+        <row id="2">
+            <value>anotherpassword</value>
+        </row>
+    </table>
+    <table name="Cluster">
+        <row id="1">
+            <cluster_token>cluster_password</cluster_token>
+        </row>
+    </table>
+    <table name="VM">
+        <row id="1"
+        NVRAM="(('EFI-variables'%.'myprivatedata'))"
+        snapshot_metadata="('NVRAM'%.'(('_%.'_')%.(\'EFI-variables\'%.\'mydata\')()">
+        </row>
+    </table>
+</root>
+"""
+
+# Same as original, but with passwords and private data replaced by: "REMOVED"
+expected = r"""<?xml version="1.0" ?>
+<root>
+    <table name="secret">
+        <row id="1" value="REMOVED">
+            <value/>
+        </row>
+        <row id="2" value="REMOVED">
+            <value/>
+        </row>
+    </table>
+    <table name="Cluster">
+        <row cluster_token="REMOVED" id="1">
+            <cluster_token/>
+        </row>
+    </table>
+    <table name="VM">
+        <row NVRAM="(('EFI-variables'%.'REMOVED'))" id="1" snapshot_metadata="('NVRAM'%.'(('_%.'_')%.(\'EFI-variables\'%.\'REMOVED\')()"/>
+    </table>
+</root>
+"""
+
+
+def assert_xml_element_trees_equiv(a, b):
+    """Assert that the contents of two XML ElementTrees are equivalent (recursive)"""
+    # Check the XML tag
+    assert a.tag == b.tag
+    # Check the XML text
+    assert (a.text or "").strip() == (b.text or "").strip()
+    # Check the XML tail
+    assert (a.tail or "").strip() == (b.tail or "").strip()
+    # Check the XML attributes
+    assert a.attrib.items() == b.attrib.items()
+    # Compare the number of child nodes
+    assert len(list(a)) == len(list(b))
+    # Recursively repeat for all child nodes (expect same order of child nodes):
+    for achild, bchild in zip(list(a), list(b)):
+        assert_xml_element_trees_equiv(achild, bchild)
+
+
+def assert_xml_str_equiv(filtered, expected):
+    """Assert that the given dummy Xen-API database to filtered as expected"""
+
+    # Works for Python2 equally, so we can use it to check Python2/3 to work.:
+    assert_xml_element_trees_equiv(fromstring(filtered), fromstring(expected))
+
+    # Double-check with parseString(): Its output will differ between Py2/Py3
+    # though, so we will use it for one language version at a time:
+    if sys.version_info < (3, 0):  # pragma: no cover
+        assert parseString(filtered).toprettyxml(indent="    ") == expected
+
+
+def test_xapi_database_filter(bugtool):
+    """Assert bugtool.DBFilter().output() filters xAPI database like expected"""
+
+    filtered = bugtool.DBFilter(original).output()
+    assert_xml_str_equiv(filtered, expected)
+
+
+def test_filter_xenstore_secrets(bugtool):
+    """Assert that filter_xenstore_secrets() does not filter non-secrets"""
+
+    assert bugtool.filter_xenstore_secrets(b"not secret", "_") == b"not secret"

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -470,6 +470,13 @@ def no_unicode(x):
         return x.encode('utf-8')
     return x
 
+
+def log_internal_error(e):
+    """Log an internal error and return an empty string as bugtool output data"""
+    log("bugtool: Internal error: " + traceback.format_exc())
+    return ""  # For now, no diagnostic output in the individual output files
+
+
 def log(x, print_output=True):
     if print_output:
         output(x)
@@ -1394,6 +1401,9 @@ def filter_xenstore_secrets(s, state):
 def filter_xapi_clusterd_db(cap):
     clusterd_data = {}
 
+    if not os.path.exists(XAPI_CLUSTERD):
+        return ""
+
     try:
         with open(XAPI_CLUSTERD, 'r') as f:
             clusterd_data = json.load(f)
@@ -1410,8 +1420,8 @@ def filter_xapi_clusterd_db(cap):
         if "token" in clusterd_data:
             clusterd_data["token"] = "REMOVED"
         output_str = json.dumps(clusterd_data)
-    except Exception:
-        output_str = ''
+    except Exception as e:
+        return log_internal_error(e)
 
     return output_str
 

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1401,8 +1401,11 @@ def filter_xapi_clusterd_db(cap):
         config_keys = ['cluster_config', 'old_cluster_config']
         for config_key in config_keys:
             if config_key in clusterd_data.keys():
-                clusterd_data[config_key]['pems']['blobs'] = "REMOVED"
-                clusterd_data[config_key]['authkey'] = "REMOVED"
+                conf = clusterd_data[config_key]
+                if "pems" in conf and "blobs" in conf["pems"]:
+                    conf["pems"]["blobs"] = "REMOVED"
+                if "authkey" in conf:
+                    conf["authkey"] = "REMOVED"
 
         if "token" in clusterd_data:
             clusterd_data["token"] = "REMOVED"

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -537,6 +537,13 @@ def func_output(cap, label, func):
     if cap in entries:
         data[label] = {'cap': cap, 'func': func}
 
+
+def include_inventory(archive, subdir):
+    inventory = {'cap': None, 'output': StringIOmtime(no_unicode(make_inventory(data, subdir)))}
+    archive.add_path_with_data(construct_filename(subdir, 'inventory.xml', inventory),
+                StringIOmtime(no_unicode(make_inventory(data, subdir))))
+
+
 def collect_data(subdir, archive):
     process_lists = {}
 
@@ -1162,9 +1169,7 @@ exclude those logs from the archive.
     collect_data(subdir, archive)
 
     # include inventory
-    inventory = {'cap': None, 'output': StringIOmtime(no_unicode(make_inventory(data, subdir)))}
-    archive.add_path_with_data(construct_filename(subdir, 'inventory.xml', inventory),
-                StringIOmtime(no_unicode(make_inventory(data, subdir))))
+    include_inventory(archive, subdir)
 
     if archive.close():
         res = 0

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1404,6 +1404,8 @@ def filter_xapi_clusterd_db(cap):
                 clusterd_data[config_key]['pems']['blobs'] = "REMOVED"
                 clusterd_data[config_key]['authkey'] = "REMOVED"
 
+        if "token" in clusterd_data:
+            clusterd_data["token"] = "REMOVED"
         output_str = json.dumps(clusterd_data)
     except Exception:
         output_str = ''


### PR DESCRIPTION
Merge to branches/xs8 and equally to branches/yangze:

- Backport the test suite that provides test coverage for 82% of xen-bugtool's lines.
- Backport #67 for XS8 and Yangtze

It's fine to review using the "Files" tab, and click on the file `xen-bugtool` at the end of the list.

I can split it into two PRs if needed.

https://github.com/xenserver/status-report/pull/75/files#diff-1a92a2104da73c38e3514b86521ab0069fd49a683c463409987c60589f4da0ab

As part of this Backport PR, only these commits touch xen-bugtool:
- [Add tests/unit/test_output.py -> move make_inventory into a def](https://github.com/xenserver/status-report/pull/75/commits/02a8e99170bc86e1fb3a4449f8cea9baca06fc70)
  - (backport of moving 2 lines into a function, for the unit test)
- [CA-358870: Fix 1: filter_xapi_clusterd_db: remove token from the report](https://github.com/xenserver/status-report/pull/75/commits/82114878b3ec71ee9d9871337bb6adc98493c409)
  - Fix removing the token field from the filtered DB (backport of @edwintorok's patch) 
- [CA-388587: Fix 2: Filter xapi-clusterd DB even when PEMs are in files…](https://github.com/xenserver/status-report/pull/75/commits/0b861236bda26f40db4a76c5939761ebc6794abf)
  - Fix `KeyError` if `pems` and `authkey` don't exist in DB (backport of @edwintorok's patch)
- [CA-388587: Fix 3: Log any errors in filter_xapi_clusterd_db()](https://github.com/xenserver/status-report/pull/75/commits/cc003c8d3cb4234a968b46148a327be10aa00793)
  - If Exceptions would occur in the future, log them to the bugtool log (with testcase for it)