### PR TITLE
CA-358870: Backport the fixes from #67 to filter the XAPI ClusterD DB for XS8, Yangtze

### DIFF
--- a/tests/unit/test_filter_xapi_clusterd_db.py
+++ b/tests/unit/test_filter_xapi_clusterd_db.py
@@ -107,7 +107,7 @@ ORIGINAL = r"""
 # Same as original, but with passwords and private data replaced by: "REMOVED"
 # BUG: "secret-token" has to be replaced by "REMOVED"
 EXPECTED = r"""{
-    "token": "secret-token",
+    "token": "REMOVED",
     "cluster_config": {
         "pems": {
             "blobs": "REMOVED"
@@ -189,7 +189,6 @@ def test_pems_blobs(isolated_bugtool):
 
 
 # CA-358870: filter_xapi_clusterd_db: remove token from the report
-@pytest.mark.xfail(reason="bugtool currently fails to remove the token")
 def test_remove_token(isolated_bugtool):
     """CA-358870: Assert that filter_xapi_clusterd_db() removes the token"""
 

--- a/tests/unit/test_filter_xapi_clusterd_db.py
+++ b/tests/unit/test_filter_xapi_clusterd_db.py
@@ -80,8 +80,6 @@ TODO END.
 import json
 import os
 
-import pytest
-
 
 # Minimal example of a xapi-clusterd/db file, with sensitive data
 # BUG: The new cluster_config has no "pems" key, so the filter has to be updated
@@ -200,7 +198,6 @@ def test_remove_token(isolated_bugtool):
     assert_filter_xapi_clusterd_db(isolated_bugtool, ORIGINAL, expected_json)
 
 
-@pytest.mark.xfail(reason="bugtool currently fails to handle missing authkey")
 def test_no_authkey(isolated_bugtool):
     """Assert that filter_xapi_clusterd_db() handles missing authkey"""
 
@@ -220,7 +217,6 @@ def test_no_authkey(isolated_bugtool):
     )
 
 
-@pytest.mark.xfail(reason="bugtool currently fails to handle missing pems")
 def test_no_pems(isolated_bugtool):
     """Assert that filter_xapi_clusterd_db() handles missing pems"""
 
@@ -240,7 +236,6 @@ def test_no_pems(isolated_bugtool):
     )
 
 
-@pytest.mark.xfail(reason="bugtool currently fails to handle missing pems.blobs")
 def test_no_blobs(isolated_bugtool):
     """Assert that filter_xapi_clusterd_db() handles missing blobs"""
 

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1396,8 +1396,11 @@ def filter_xapi_clusterd_db(cap):
         config_keys = ['cluster_config', 'old_cluster_config']
         for config_key in config_keys:
             if config_key in clusterd_data.keys():
-                clusterd_data[config_key]['pems']['blobs'] = "REMOVED"
-                clusterd_data[config_key]['authkey'] = "REMOVED"
+                conf = clusterd_data[config_key]
+                if "pems" in conf and "blobs" in conf["pems"]:
+                    conf["pems"]["blobs"] = "REMOVED"
+                if "authkey" in conf:
+                    conf["authkey"] = "REMOVED"
 
         if "token" in clusterd_data:
             clusterd_data["token"] = "REMOVED"

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1399,6 +1399,8 @@ def filter_xapi_clusterd_db(cap):
                 clusterd_data[config_key]['pems']['blobs'] = "REMOVED"
                 clusterd_data[config_key]['authkey'] = "REMOVED"
 
+        if "token" in clusterd_data:
+            clusterd_data["token"] = "REMOVED"
         output_str = json.dumps(clusterd_data)
     except Exception:
         output_str = ''

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -470,6 +470,13 @@ def no_unicode(x):
         return x.encode('utf-8')
     return x
 
+
+def log_internal_error(e):
+    """Log an internal error and return an empty string as bugtool output data"""
+    log("bugtool: Internal error: " + traceback.format_exc())
+    return ""  # For now, no diagnostic output in the individual output files
+
+
 def log(x, print_output=True):
     if print_output:
         output(x)
@@ -1389,6 +1396,9 @@ def filter_xenstore_secrets(s, state):
 def filter_xapi_clusterd_db(cap):
     clusterd_data = {}
 
+    if not os.path.exists(XAPI_CLUSTERD):
+        return ""
+
     try:
         with open(XAPI_CLUSTERD, 'r') as f:
             clusterd_data = json.load(f)
@@ -1405,8 +1415,8 @@ def filter_xapi_clusterd_db(cap):
         if "token" in clusterd_data:
             clusterd_data["token"] = "REMOVED"
         output_str = json.dumps(clusterd_data)
-    except Exception:
-        output_str = ''
+    except Exception as e:
+        return log_internal_error(e)
 
     return output_str
 


### PR DESCRIPTION
CA-358870: Backport the fixes to filter the XAPI Clusterd DB for XS8, Yangtze:

Fixes for `filter_xapi_clusterd_db():`
1. Remove the clusterd token (backport of @edwintorok's patch)
   (cherry picked from #67, 9a64b448d4431ebe228652421ef4e80131e95bb1)
3. Fix `KeyError` if `pems` and `authkey` don't exist in DB (backport of @edwintorok's patch)
   (cherry picked from #67, e4a80b6e7f433ed72cce0045eb240d112fd73e78)
2. Log any errors in filter_xapi_clusterd_db()
   If Exceptions would occur in the future, log them to the bugtool log (with testcase for it)
   (cherry picked from #67, 5fd22f80f7f21a675e70454db4b12089620320fd)