### PR TITLE
Fix test for `disk_list()` to be OS-agnostic and test the major device number filter

### DIFF
--- a/tests/unit/test_fs_funcs.py
+++ b/tests/unit/test_fs_funcs.py
@@ -19,6 +19,36 @@ def test_read_inventory(bugtool, dom0_template):
     assert inventory["PRODUCT_VERSION"] == "8.3.0"
 
 
-def test_disk_list(bugtool):
-    """Assert that the return value of disk_list() contains sda or nvme0n1"""
-    assert "sda" in bugtool.disk_list() or "nvme0n1" in bugtool.disk_list()
+def test_disk_list(bugtool, tmpdir):
+    """Test bugtool.disk_list() to filter disks an only return native disks"""
+
+    # Arrange:
+
+    # Save the original value of bugtool.PROC_PARTITIONS and set it to the new file:
+    proc_partitions = bugtool.PROC_PARTITIONS
+
+    # Replace the original file with a new one:
+    bugtool.PROC_PARTITIONS = str(tmpdir.join("partitions"))
+    tmpdir.join("partitions").write(
+        """major minor  #blocks  name
+
+    8    0  125034840 sda
+    8    1  125033856 sda1
+    8   16  125034840 sdb
+    8   17  125033856 sdb1
+    220  0  125034840 xvda
+    220  1  125033856 xvda1
+    259  0  125034840 nvme0n1
+    259  1  125033856 nvme0n1p1
+    """
+    )
+
+    # Assert:
+
+    # nvme0n1 is removed by disk_list as its major number is 259 (not < 254):
+    assert bugtool.disk_list() == ["sda", "sdb"]
+
+    # Restore:
+
+    # Restore the original value of bugtool.PROC_PARTITIONS:
+    bugtool.PROC_PARTITIONS = proc_partitions

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -2147,16 +2147,16 @@ def mdadm_arrays():
 partition_re = re.compile(r'(.*[0-9]+$)|(^xvd)')
 
 def disk_list():
+    """Return a list of native disks, excluding partitions and virtual disks."""
     disks = []
     try:
-        f = open('/proc/partitions')
-        f.readline()
-        f.readline()
-        for line in f.readlines():
-            major, _, _, name = line.split()
-            if int(major) < 254 and not partition_re.match(name):
-                disks.append(name)
-        f.close()
+        with open(PROC_PARTITIONS, "r") as f:
+            f.readline()
+            f.readline()
+            for line in f.readlines():
+                major, _, _, name = line.split()
+                if int(major) < 254 and not partition_re.match(name):
+                    disks.append(name)
     except:
         pass
     return disks


### PR DESCRIPTION
Fix the test of `disk_list()` to be host/OS-independent and test also the major device number filter in it:

- the 1st commit only prepares the code for the new test and the tested return value does not change in GitHub CI.
- the 2nd commit then updates the test to be a proper test, checking the branches in the function to perform as expected (e.g. devices with major device id >= 245 are filtered out)

In short, the commits are:

1. Update xen-bugtool.disk_list() to use the existing PROC_PARTITIONS variable (and also use `with open()`)
2. Update the test case to supply much better test data showing the filtering that the function is implemented to do to work.