### PR TITLE
CP-48196: Add a unit-test for `dump_xapi_subprocess_info()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,6 +130,7 @@ repos:
         additional_dependencies:
         - coverage
         - defusedxml
+        - pyfakefs
         - pytest-coverage
         - pytest-mock
         - lxml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 lxml
+pyfakefs
 pytest-coverage
 pytest-mock

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,8 +15,18 @@ from __future__ import print_function
 import os
 import shutil
 import sys
+from types import ModuleType
 
 import pytest
+
+#
+# Prevent the import of the pandas module: It is not needed for unit tests:
+# But pyfakefs tries to import it for patching it. This is not needed and
+# causes a DeprecationWarning when Pandas is imported: It warns that the
+# pyarrow backend is deprecated and will be removed in a future version. Also,
+# the time to import pandas is very noticeable(0.3s) when starting tests:
+#
+sys.modules["pandas"] = ModuleType("pandas")
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/test_dump_xapi_procs.py
+++ b/tests/unit/test_dump_xapi_procs.py
@@ -1,0 +1,34 @@
+"""This module contains the unit tests for the dump_xapi_procs function"""
+
+import sys
+
+
+def test_dump_xapi_subprocess_info(bugtool, fs):
+    """Test the dump_xapi_subprocess_info() function to perform as expected"""
+
+    # Prepare the virtual pyfakefs filesystem for the test
+
+    fs.create_file("/proc/2/status", contents="PPid: 1")
+    fs.create_file("/proc/3/status", contents="PPid: 2")
+    fs.create_file("/proc/4/status", contents="")
+    fs.create_file("/proc/2/cmdline", contents="/opt/xensource/bin/xapi")
+    fs.create_file("/proc/3/cmdline", contents="/bin/sh")
+    fs.create_file("/proc/4/cmdline", contents="")
+    fs.create_symlink("/proc/2/fd/1", "/dev/null")
+    fs.create_symlink("/proc/3/fd/0", "/dev/zero")
+
+    # Prepare the expected result
+
+    expected_result = """{   '2': {   'children': {   '3': {   'children': {},
+                                      'cmdline': '/bin/sh',
+                                      'fds': {'0': '/dev/zero'}}},
+             'cmdline': '/opt/xensource/bin/xapi',
+             'fds': {'1': '/dev/null'}}}"""
+
+    if sys.version_info.major == 2:  # pragma: no cover
+        expected_result = expected_result.replace("{}", "{   }")
+        expected_result = expected_result.replace(": {'", ": {   '")
+
+    # Assert the expected result
+
+    assert bugtool.dump_xapi_subprocess_info("cap") == expected_result


### PR DESCRIPTION
Add a unit-test for `dump_xapi_subprocess_info()` which covers all lines of the function:

https://app.codecov.io/gh/xenserver/status-report/pull/85/indirect-changes