### PR TITLE
Fix yes/no input for Python2/XS8: revert to raw_input() on Python2

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -118,10 +118,15 @@ def patch_bugtool(bugtool, mocker, dom0_template, report_name, tmp_path):
     bugtool.DB_CONF = xensource_db_conf
 
     # To cover the the code resulting from inputting "n", we need to mock input:
-    def input(prompt):
+    def return_no_for_proc_files(prompt):
+        """Mock the input() function to return "n" when prompted for /proc files"""
+
         return "n" if "/proc" in prompt else "y"
 
-    bugtool.input = input
+    if sys.version_info.major == 2:  # pragma: no cover
+        bugtool.raw_input = return_no_for_proc_files
+    else:
+        bugtool.input = return_no_for_proc_files
 
     entries = [
         "xenserver-config",

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -2172,7 +2172,10 @@ def capability(document, key):
 
 
 def yes(prompt):
-    yn = input(prompt)
+    if sys.version_info.major == 2:  # pragma: no cover
+        yn = raw_input(prompt)  # pyright: ignore[reportUndefinedVariable]
+    else:
+        yn = input(prompt)
 
     return len(yn) == 0 or yn.lower()[0] == 'y'
 


### PR DESCRIPTION
Python2 `input()` is eqivalent to: `eval(raw_input())`, which was wrong for Python2. Fix it.

For reading input lines like `y` (without "quotes") from stdin, we need to use `raw_input()` on Python2.

AshwinH contributed this comment in his approval:
Documentation for this change :https://codeql.github.com/codeql-query-help/python/py-use-of-input/