### PR TITLE
Fix to preserve the directory traversal order in Python2

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -58,6 +58,7 @@ import time
 import traceback
 import xml
 import zipfile
+from collections import OrderedDict
 from hashlib import md5 as md5_new
 from select import select
 from signal import SIGHUP, SIGTERM, SIGUSR1
@@ -497,7 +498,7 @@ dictionaries with the following keys:
   - "filter": An optional filter function to pass the file data through
 """
 
-directory_specifications = {}
+directory_specifications = OrderedDict()
 dev_null = open('/dev/null', 'r+')
 
 


### PR DESCRIPTION
For the external bugtool plugin `xcp-rrdd-plugins`, the order of the directory traversal of the trees it collects is important:

File `/etc/xensource/bugtool/xcp-rrdd-plugins.xml`:
```xml
<capability pii="maybe" max_size="1638400" max_time="60" mime="text/plain" checked="true"/>
```

File `/etc/xensource/bugtool/xcp-rrdd-plugins/stuff.xml`:
```xml
<collect>
  <directory pattern=".*xcp-rrdd-plugins\.log.*">/var/log</directory>
  <directory label="rrdd_shm">/dev/shm/metrics</directory>
</collect>
```

`/dev/shm/metrics/xcp-rrdd-iostat` is a sparse file that may hold just 8k of actual data, but its apparent size is ~8 MB. Using the current algorithm, the large, sparse file gets added nonetheless. But after it, the max_size limit of 1.6 MB set by the plugin's `.xml` is exceeded, and file_output then rejects further files in the same cap.

When `xen-bugtool --all` is used, Python2 no longer preserves the order of the directories in the directory_specifications variable.

Then, /dev/shm/metrics is collected before /var/log/xcp-rrdd-plugins, which means that -rrdd-plugins log files are NOT collected.

Of course, as described, also other factors are to blame:
- Not getting the actual, but the apparent sparse file size
- Collecting too large files that exceed the limits instead of rejecting them (which would allow small files after them).

But the immediate trigger for this regression is not preserving the directory order in Python 2.

Fix it by using OrderedDict() (like Python 3 always does anyway) for the directory_specifications dictionary (only two dozen entries).