### PR TITLE
Fix mocking the `xen-bugtool` script in with Python 3.12 

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -78,7 +78,14 @@ def imported_bugtool(testdir, dom0_template):
             spec.loader.exec_module(module)
             return module
 
-    bugtool = import_from_file("xen-bugtool", testdir + "/../../xen-bugtool")
+    #
+    # Import the xen-bugtool script as a module:
+    # Python3.12's mocker.patch() stopped supporting modules with a "-" in them.
+    #
+    # Use "bugtool" as the module name instead of "xen-bugtool" to avoid this
+    # problem with the mocker.patch() function in Python 3.12.
+    #
+    bugtool = import_from_file("bugtool", testdir + "/../../xen-bugtool")
     bugtool.ProcOutput.debug = True
 
     # Prepend tests/mocks to force the use of our mock xen.lowlevel.xc module:

--- a/tests/unit/test_dump_xapi_rrds.py
+++ b/tests/unit/test_dump_xapi_rrds.py
@@ -132,9 +132,9 @@ def assert_mock_session1(bugtool, mock_urlopen):
 def run_dump_xapi_rrds(mocker, bugtool, mock_session, mock_urlopen):
     """Run the bugtool function dump_xapi_rrds(entries) with the given mocks."""
     # Patch the urlopen, xapi_local_session and entries
-    mocker.patch("xen-bugtool.urlopen", side_effect=mock_urlopen)
-    mocker.patch("xen-bugtool.xapi_local_session", return_value=mock_session)
-    mocker.patch("xen-bugtool.entries", [bugtool.CAP_PERSISTENT_STATS])
+    mocker.patch("bugtool.urlopen", side_effect=mock_urlopen)
+    mocker.patch("bugtool.xapi_local_session", return_value=mock_session)
+    mocker.patch("bugtool.entries", [bugtool.CAP_PERSISTENT_STATS])
 
     # Run the function
     bugtool.dump_xapi_rrds(bugtool.entries)

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -56,7 +56,7 @@ def assert_mock_bugtool_plugin_output(temporary_directory, subdir, names):
 def minimal_bugtool(bugtool, dom0_template, archive, subdir, mocker):
     """Load the plugins from the template and include the generated inventory"""
 
-    mocker.patch("xen-bugtool.time.strftime", return_value="time.strftime")
+    mocker.patch("bugtool.time.strftime", return_value="time.strftime")
     # Load the mock plugin from dom0_template and process the plugin's caps:
     bugtool.PLUGIN_DIR = dom0_template + "/etc/xensource/bugtool"
     bugtool.entries = ["mock"]


### PR DESCRIPTION
### Fix for importing and mocking the `xen-bugtool` script as a module in Python 3.12:

Python3.12's `mocker.patch()` stopped supporting modules with a `"-"` in them.

Use `"bugtool"` as the module name instead of `"xen-bugtool"` to avoid this problem with the mocker.patch() function in Python 3.12.

The other commit in this PR for the dictionary file is needed to fix the spellcheck in CI.