### PR TITLE
CP-48444: Fix crash of Python3.6 with "Illegal seek" with --outfd

### DIFF
--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -170,6 +170,7 @@ rrdd
 rrds
 sar
 sbin
+seekable
 SETFD
 setgroups
 SIGUSR
@@ -189,6 +190,7 @@ subarchive
 subarchives
 subclasses
 subdir
+subdirectories
 subdirectory
 subprocesses
 swtpm

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -265,7 +265,6 @@ def test_main_func_output_to_zipfile(patched_bugtool, capfd):
     assert_valid_inventory(bugtool, args, capfd, tmp_path, base_path, filetype)
 
 
-@pytest.mark.skipif(sys.version_info < (3,), reason="GitHub CI flaky for it")
 def test_main_func_output_to_tarfd(patched_bugtool, capfd):
     """Assert writing a tar fd creates a tarball with a valid XML inventory
 

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1920,7 +1920,11 @@ class TarOutput(ArchiveWithTarSubarchives):
         if output_fd == -1:
             self.tf = tarfile.open(self.filename, mode)
         else:
-            self.tf = tarfile.open(None, 'w|', os.fdopen(output_fd, 'ab'))
+            try:  # Python3.6 does not support "ab" if the file is not seekable:
+                binary_fileobj = os.fdopen(output_fd, "ab")
+            except OSError:  # pragma: no cover
+                binary_fileobj = os.fdopen(output_fd, "wb")
+            self.tf = tarfile.open(name=None, mode="w|", fileobj=binary_fileobj)
 
     def _getTi(self, filename):
         ti = tarfile.TarInfo(filename)


### PR DESCRIPTION
### Fix `--outfd` with Python3.6 (it does not support `fdopen(fd, 'ab')` if outfd is not seekable):
@MarkSymsCtx: Updated to try to append and fall back only when seeking to append fails:
```py
            try:  # Python3.6 does not support "ab" if the file is not seekable:
                binary_fileobj = os.fdopen(output_fd, "ab")
            except OSError:  # pragma: no cover
                binary_fileobj = os.fdopen(output_fd, "wb")
            self.tf = tarfile.open(name=None, mode="w|", fileobj=binary_fileobj)
```
----
### Full commit message details:

When running this command on a real XS8 Dom0, this error occurs:

```py
PYTHONPATH=tests/mocks /usr/bin/python3 ./xen-bugtool --output=tar --outfd=1 -sy|tar tvf -
Traceback (most recent call last):
  File "./xen-bugtool", line 2358, in <module>
    sys.exit(main())
  File "./xen-bugtool", line 1290, in main
    archive = TarOutput(subdir, output_type, output_fd)
  File "./xen-bugtool", line 1886, in __init__
    self.tf = tarfile.open(None, 'w|', os.fdopen(output_fd, 'ab'))
  File "/usr/lib64/python3.6/os.py", line 1017, in fdopen
    return io.open(fd, *args, **kwargs)
OSError: [Errno 29] Illegal seek
```
This is specific to Python3.6 (used on XS8).

On XS8, xen-bugtool still uses Python2, so this is a problem to fix
for when we'd switch xen-bugtool to use Python3 on XS8.

Tests:
```py
PYTHONPATH=tests/mocks /usr/bin/python3 ./xen-bugtool --output=tar --outfd=1 -sy >out.tar
tar tvf out.tar
PYTHONPATH=tests/mocks /usr/bin/python3 ./xen-bugtool --output=tar --outfd=1 -sy|tar tvf -
PYTHONPATH=tests/mocks /usr/bin/python2 ./xen-bugtool --output=tar --outfd=1 -sy|tar tvf -
```
(tar archive output is listed as expected)