### PR TITLE
CP-48447+CA-390127: correct exception handling for func_output callbacks, fix saving all log messages

### DIFF
--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -8,6 +8,7 @@ authkey
 autoflake
 autouse
 backend
+backtrace
 basename
 basepath
 basestring
@@ -57,6 +58,7 @@ dir
 dircmp
 dirs
 docstrings
+dont
 dp
 dunder
 efi
@@ -127,6 +129,7 @@ networkd
 NEWNET
 NEWNS
 nonexisting
+NOSONAR
 NRPE
 nsswitch
 nvme
@@ -189,6 +192,7 @@ subarchive
 subarchives
 subclasses
 subdir
+subdirectories
 subdirectory
 subprocesses
 swtpm

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -245,14 +245,9 @@ def assert_bugtool_logfile_data(logfile):
     # caught and logged, the log file should contain the backtrace from the
     # raised exception:
     #
-    # FIXME: This is not working in Python 2.7 yet (in this specific case): CA-390127
-    # CA-390127 affects Python3 in principle too, but it does not make this test fail
-    # Fixing CA-390127 is a prerequisite for enabling this check for Python 2.7:
-    #
-    if sys.version_info.major > 2:  # pragma: no cover
-        assert len(lines) == 9
-        for backtrace_string in MOCK_EXCEPTION_STRINGS:
-            assert backtrace_string in log
+    assert len(lines) == 9
+    for backtrace_string in MOCK_EXCEPTION_STRINGS:
+        assert backtrace_string in log
 
 
 def assert_valid_inventory(bugtool, args, cap, tmp_path, base_path, filetype):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,4 +1,5 @@
 """pytest module for unit-testing xen-bugtool's main() function"""
+
 import logging
 import os
 import sys
@@ -7,8 +8,9 @@ import zipfile
 
 import pytest
 
+# sourcery skip: dont-import-test-modules
 from . import test_xapidb_filter
-from .test_output import assert_valid_inventory_schema, parse
+from .test_output import MOCK_EXCEPTION_STRINGS, assert_valid_inventory_schema, mock_data_collector, parse
 
 
 yes_to_all_warning = """\
@@ -132,6 +134,7 @@ def patch_bugtool(bugtool, mocker, dom0_template, report_name, tmp_path):
         "xenserver-config",
         "xenserver-databases",
         "mock",
+        "xen-bugtool",
         "unknown",
     ]
     sys.argv.append("--entries=" + ",".join(entries))
@@ -177,6 +180,10 @@ def check_output(bugtool, captured, tmp_path, filename, filetype):
     # Provides a nicely formatted diff (unlike str.startswith()) on assertions:
     assert captured.out[: len(out_begin)] == out_begin
 
+    # Assert that the backtrace from the mock data collector is printed:
+    for backtrace_string in MOCK_EXCEPTION_STRINGS:
+        assert backtrace_string in captured.out
+
     if bugtool.ProcOutput.debug:
         assert p + "Starting '%s list'\n" % bugtool.BIN_STATIC_VDIS in captured.out
         for ls in ("/opt/xensource", "/etc/xensource/static-vdis"):
@@ -207,9 +214,45 @@ def check_output(bugtool, captured, tmp_path, filename, filetype):
         d = xenstore_ls_f.read()
     assert d == "/local/domain/1/data/set_clipboard = <filtered for security>\n"
 
+    #
+    # Given that --entries= includes `xen-bugtool`, the output should contain a log
+    # file with the backtrace from the Exception raised by the mock data collector:
+    #
+    with open(output_directory + "/xen-bugtool.log") as logfile:
+        assert_bugtool_logfile_data(logfile)
+
     # Assertion check of the output files is missing an inventory entry:
     # Do this check in a future test which runs
     assert_valid_inventory_schema(parse(output_directory + "inventory.xml"))
+
+
+def assert_bugtool_logfile_data(logfile):
+    """
+    Given that --entries= includes `xen-bugtool`, the output should contain a log
+    file with the backtrace from the Exception raised by the mock data collector:
+    """
+    log = logfile.read()
+    lines = log.splitlines()
+    assert len(lines) >= 2
+    assert lines[0].startswith(
+        "xen-bugtool --unlimited --entries=xenserver-config,"
+        "xenserver-databases,mock,xen-bugtool,unknown --out",
+    )
+    assert lines[1].startswith("PATH=")
+
+    #
+    # Given that the exception raised by the mock data collector function is
+    # caught and logged, the log file should contain the backtrace from the
+    # raised exception:
+    #
+    # FIXME: This is not working in Python 2.7 yet (in this specific case): CA-390127
+    # CA-390127 affects Python3 in principle too, but it does not make this test fail
+    # Fixing CA-390127 is a prerequisite for enabling this check for Python 2.7:
+    #
+    if sys.version_info.major > 2:  # pragma: no cover
+        assert len(lines) == 9
+        for backtrace_string in MOCK_EXCEPTION_STRINGS:
+            assert backtrace_string in log
 
 
 def assert_valid_inventory(bugtool, args, cap, tmp_path, base_path, filetype):
@@ -228,6 +271,12 @@ def assert_valid_inventory(bugtool, args, cap, tmp_path, base_path, filetype):
     :raises AssertionError: When the output does not match the expected output.
     """
     sys.argv.extend(args)
+
+    # Given that we'd like to test handling of exceptions from func_output callbacks,
+    # we add a mock data collector function to a mock entry that raises an exception:
+    #
+    bugtool.entries = ["mock"]
+    bugtool.func_output("mock", "function_output.out", mock_data_collector)
 
     assert bugtool.main() == 0
     filename = base_path + "." + filetype

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -720,8 +720,9 @@ def collect_data(subdir, archive):
             try:
                 s = no_unicode(v["func"](cap))
             except Exception:
-                s = traceback.format_exc()
-                log(s)
+                backtrace = traceback.format_exc()  # type: str
+                log(backtrace)
+                s = backtrace.encode()
             if unlimited_data or caps[cap][MAX_SIZE] == -1 or \
                     cap_sizes[cap] < caps[cap][MAX_SIZE]:
                 v['output'] = StringIOmtime(s)

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1274,8 +1274,6 @@ exclude those logs from the archive.
     cmd_output(CAP_YUM, [RPM, '-qa'])
     tree_output(CAP_YUM, SIGNING_KEY_INFO_DIR)
 
-    file_output(CAP_XEN_BUGTOOL, [XEN_BUGTOOL_LOG])
-
     # permit the user to filter out data
     for k in sorted(data.keys()):
         if not ANSWER_YES_TO_ALL and not yes("Include '%s'? [Y/n]: " % k):
@@ -1311,6 +1309,12 @@ exclude those logs from the archive.
     # collect selected data now
     output_ts('Running commands to collect data')
     collect_data(subdir, archive)
+
+    # after all is done, include all log() entries from the XEN_BUGTOOL_LOG file
+    if CAP_XEN_BUGTOOL in entries:
+        archive.addRealFile(
+            construct_filename(subdir, XEN_BUGTOOL_LOG, {}), XEN_BUGTOOL_LOG
+        )
 
     # include inventory
     include_inventory(archive, subdir)


### PR DESCRIPTION
## Fix two issues (their tests overlap):
### CA-390127 (fix saving all log messages)

Fix adding even the last log() messages to the output archive
- In the test added (extended) for CP-48447 (below) which extends test_main.py (which calls `xen-bugtool.main()`), the exception raised and logged as part of the test execution could not be found in the `xen-bugtool.log` file that is recorded in the `bugtool` output archive.
- However, the exception was shown to be included in the `xen-bugtool.log` file itself (not in the output archive)
- The reason for this behaviour was that `xen-bugtool.log` was collected before the exception was written to it:
- Because there is no guarantee that this file is collected last, update it to be explicitly collected at the end of processing before generating the inventory.xml and closing the archive.
- This was already approved by @GeraldEV in #93, now added to this PR for merge.

### CP-48447 (correct exception handling for func_output callbacks)

A major design goal of `xen-bugtool` is to continue as well as possible when an error occurs.
This is currently failing in a specific case when Python3 would be used to run `xen-bugtool`:

* Given a raised Exception with these properties:
  * raised inside a callback function declared by `func_output()`
  * not caught inside the callback function itself
* When logging that Exception,
  * the code misses encoding the backtrace of the exception from string to bytes when attempting to add it to the BytesIO-based file buffer to be included in the output archive.
    * The secondary exception caused is then fatal.

Traceback of an example (a real variant of caused me to notice it):

Initial exception (example):
```py
Traceback (most recent call last):
  File "./xen-bugtool", line 724, in collect_data
    s = no_unicode(v["func"](cap))
  File "./xen-bugtool", line 1406, in dump_xapi_subprocess_info
    raise RuntimeError("error")
RuntimeError: error
```
This then results in a `str` (from the traceback) passed to `io.BytesIO` without encoding to bytes first, causing the 2nd, fatal Exception:
```py
Traceback (most recent call last):
  File "./xen-bugtool", line 2399, in <module>
    sys.exit(main())
  File "./xen-bugtool", line 1316, in main
    collect_data(subdir, archive)
  File "./xen-bugtool", line 730, in collect_data
    v['output'] = StringIOmtime(s)
  File "./xen-bugtool", line 511, in __init__
    io.BytesIO.__init__(self, buf)
TypeError: a bytes-like object is required, not 'str'
```
That's an issue that is detected by pyright:
```py
$ pyright xen-bugtool
xen-bugtool:730:45 - error: Argument of type "Unknown | str" cannot be assigned to parameter "buf" of type "bytes" in function "__init__"
    Type "Unknown | str" cannot be assigned to type "bytes"
      "str" is incompatible with "bytes" (reportArgumentType)
```
https://github.com/marketplace/actions/run-pyright-with-reviewdog
https://github.com/jordemort/action-pyright