### PR TITLE
CA-390127: Fix adding even the last log() messages to the output archive

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -245,14 +245,9 @@ def assert_bugtool_logfile_data(logfile):
     # caught and logged, the log file should contain the backtrace from the
     # raised exception:
     #
-    # FIXME: This is not working in Python 2.7 yet (in this specific case): CA-390127
-    # CA-390127 affects Python3 in principle too, but it does not make this test fail
-    # Fixing CA-390127 is a prerequisite for enabling this check for Python 2.7:
-    #
-    if sys.version_info.major > 2:  # pragma: no cover
-        assert len(lines) == 9
-        for backtrace_string in MOCK_EXCEPTION_STRINGS:
-            assert backtrace_string in log
+    assert len(lines) == 9
+    for backtrace_string in MOCK_EXCEPTION_STRINGS:
+        assert backtrace_string in log
 
 
 def assert_valid_inventory(bugtool, args, cap, tmp_path, base_path, filetype):

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1278,8 +1278,6 @@ exclude those logs from the archive.
     cmd_output(CAP_YUM, [RPM, '-qa'])
     tree_output(CAP_YUM, SIGNING_KEY_INFO_DIR)
 
-    file_output(CAP_XEN_BUGTOOL, [XEN_BUGTOOL_LOG])
-
     # permit the user to filter out data
     for k in sorted(data.keys()):
         if not ANSWER_YES_TO_ALL and not yes("Include '%s'? [Y/n]: " % k):
@@ -1315,6 +1313,12 @@ exclude those logs from the archive.
     # collect selected data now
     output_ts('Running commands to collect data')
     collect_data(subdir, archive)
+
+    # after all is done, include all log() entries from the XEN_BUGTOOL_LOG file
+    if CAP_XEN_BUGTOOL in entries:
+        archive.addRealFile(
+            construct_filename(subdir, XEN_BUGTOOL_LOG, {}), XEN_BUGTOOL_LOG
+        )
 
     # include inventory
     include_inventory(archive, subdir)


### PR DESCRIPTION
CA-390127: Fix adding even the last log() messages to the output archive

The merge target of this PR is the same commit as in #92:

The reason for this is that this commit of #92 includes the needed unit test as the basis to verify this fix with an update to the unit test of #92.

Please review #92 as well, and after #92 is merged, I'll change the target of this PR to master (and I'll notify you for a final re-approval then)