### PR TITLE
CA-390129: Handle & log exceptions in dump_xapi_rrds(hidden and disabled)

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -59,6 +59,7 @@ import traceback
 import xml
 import zipfile
 from collections import OrderedDict
+from contextlib import contextmanager
 from hashlib import md5 as md5_new
 from select import select
 from signal import SIGHUP, SIGTERM, SIGUSR1
@@ -520,7 +521,16 @@ def no_unicode(x):
     return x
 
 
-def log_internal_error(e):
+@contextmanager
+def log_exceptions():
+    """Context manager to log exceptions."""
+    try:
+        yield
+    except Exception as e:  # pylint: disable=broad-except
+        log("%s, %s" % (e, traceback.format_exc()))
+
+
+def log_internal_error(_):
     """Log an internal error and return an empty string as bugtool output data"""
     log("bugtool: Internal error: " + traceback.format_exc())
     return ""  # For now, no diagnostic output in the individual output files
@@ -1130,7 +1140,8 @@ exclude those logs from the archive.
     # tree_output(CAP_PAM, SAMBA_DATA_DIR) # Explictly skip samba data as it contains credentials
     tree_output(CAP_PAM, VAR_LOG_DIR + "samba")
 
-    dump_xapi_rrds(entries)
+    with log_exceptions():
+        dump_xapi_rrds(entries)
 
     cmd_output(CAP_PROCESS_LIST, [PS, 'wwwaxf', '-eo', 'pid,tty,stat,time,nice,psr,pcpu,pmem,nwchan,wchan:25,args'], label='process-tree')
     func_output(CAP_PROCESS_LIST, 'fd_usage', fd_usage)


### PR DESCRIPTION
CA-390129: Handle & log exceptions in `dump_xapi_rrds()` from `xen-bugtool --entries=persistent-stats`:

While this capability is hidden, is executed when `xen-bugtool -y -a` is called.