### PR TITLE
CA-390129: Add the unit test case for the exception handler added in #94

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,6 +119,15 @@ repos:
         files: '(^xen-bugtool|\.py)$'
 
 
+# --------------------
+# Hint about this hook
+# --------------------
+#
+# If you want to skip this hook (in case the branch shall not be rebased), use:
+# export SKIP=check-branch-needs-rebase or (for example):
+# SKIP=check-branch-needs-rebase pre-commit run --hook-stage push --all-files -v
+# SKIP=check-branch-needs-rebase git commit -s -m "your message"
+#
 -   repo: local
     hooks:
     -   id: check-branch-needs-rebase


### PR DESCRIPTION
This new test confirms that `log_exceptions()` (added with #94) logs exception messages to the collected xen-bugtool.log file and to stdout.

This PR also has a 2nd commit with a note on how to best skip a pre-commit check for rebasing the PR branch:
- As an exception from the norm of "one PR, one topic", I think that adding this 2nd commit here is fine because both are very small changes, and we don't need a separate PR just to add a hint for developers.