### PR TITLE
CA-390759: Revert removal of PBIS (PowerBroker Identity Service) for future backports.

### DIFF
--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -8,6 +8,7 @@ authkey
 autoflake
 autouse
 backend
+backporting
 backtrace
 basename
 basepath
@@ -113,6 +114,7 @@ logfiles
 LOSETUP
 lowlevel
 ltex
+lwidentity
 maxsplit
 mdadm
 mdstat

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -219,6 +219,18 @@ YUM_LOG = '/var/log/yum.log'
 YUM_REPOS_DIR = '/etc/yum.repos.d'
 PAM_DIR = '/etc/pam.d'
 FIST_RE = re.compile(r'.*/fist_')
+# -------------------------------------------------------------------------------
+# LWIDENTITY files and LIKEWISE_DIR are added as basis for backporting to 8.2 CU1
+
+# LWIDENTITY_JOIN_LOG is a temporary file created by lwidentity-join
+LWIDENTITY_JOIN_LOG = "/tmp/lwidentity.join.log"
+
+# HOSTS_LWIDENTITY_ORIG is a backup of /etc/hosts created by lwidentity-join
+HOSTS_LWIDENTITY_ORIG = "/etc/hosts.lwidentity.orig"
+
+# Likewise configuration files
+LIKEWISE_DIR = "/var/lib/likewise"
+# -------------------------------------------------------------------------------
 KRB5_CONF = '/etc/krb5.conf'
 SAMBA_CONFIG_DIR = '/etc/samba'
 # SAMBA_DATA_DIR = '/var/lib/samba'
@@ -1135,6 +1147,7 @@ exclude those logs from the archive.
 
     tree_output(CAP_PAM, PAM_DIR)
     file_output(CAP_PAM, [KRB5_CONF, SSHD_CONFIG])
+    tree_output(CAP_PAM, LIKEWISE_DIR)
     file_output(CAP_PAM, [AD_USERS, AD_GROUPS])
     tree_output(CAP_PAM, SAMBA_CONFIG_DIR)
     # tree_output(CAP_PAM, SAMBA_DATA_DIR) # Explictly skip samba data as it contains credentials
@@ -1166,6 +1179,7 @@ exclude those logs from the archive.
                            'blktap.log.%d', 'wtmp.%d.gz']]])
     if not os.path.exists('/var/log/dmesg') and not os.path.exists('/var/log/boot.msg'):
         cmd_output(CAP_SYSTEM_LOGS, [DMESG])
+    file_output(CAP_SYSTEM_LOGS, [LWIDENTITY_JOIN_LOG, HOSTS_LWIDENTITY_ORIG])
 
     cmd_output(CAP_SYSTEM_SERVICES, [CHKCONFIG, '--list'])
     cmd_output(CAP_SYSTEM_SERVICES, [SYSTEMCTL, 'status'])


### PR DESCRIPTION
While this reverts the removal of PBIS support in the master branch (that master would not need now), it would make sense to apply revert the removal of it in master as well to be able to use the master branch as basis for future hotfixes again like we did for UPD-948 (StatusQuo): One example where it could be decided to do this gain would be syncing of RRDs to disk before capturing them which is planned for 8.2 CU1. It would involve backporting the larger patch of https://github.com/xenserver/status-report/pull/51 which resulted in an issue that needs https://github.com/xenserver/status-report/pull/88. Using master like UPD-948 did would be an option for this future release. But for this to be have no regressions, we should also apply this to master:

XS8 migrated from PowerBroker Identity Service (PBIS) to Samba Winbind, but Yangtze keeps using PBIS:
https://docs.xenserver.com/en-us/xenserver/8/whats-new.html (CP-36092)

In 2021 the collection of PBIS was replaced by collecting Samba Winbind data and for the previous hotfix, with the release of v1.2.10 for 8.2 CU1, that removal of PBIS collection was re-added, but only in the branch for Yangtze. But the commit was labelled as Backport (Backport means: The change is ported from the trunk/head/master to an older branch), which it wasn't a backport at all (it was a revert, like this PR):

It reverted removing PBIS that was removed in master. This together with the recommendation to update `bugtool` in Yangtze using the master branch led to this revert not being included in the new, updated release branch for Yangtze: https://github.com/xenserver/status-report/tree/release/yangtze

Fix this by forward-porting this revert of the PBIS removal (final commit of v1.2.10) to the new Yangtze branch for the next Yangtze hotfix: https://github.com/xenserver/status-report/compare/master...historic/yangtze/lcm

The aim of PR is to forward-port the "backport" to the master branch until the support for Yangtze ends to prevent this from happening in the future again, and then backport it to https://github.com/xenserver/status-report/tree/release/yangtze as it should have been done.