### PR TITLE
CP-48198: test_filter_xapi_clusterd_db.py: Self-test asserting the expected output

### DIFF
--- a/tests/unit/test_filter_xapi_clusterd_db.py
+++ b/tests/unit/test_filter_xapi_clusterd_db.py
@@ -96,9 +96,9 @@ import json
 import os
 import re
 
+import pytest
+
 # Minimal example of a xapi-clusterd/db file, with sensitive data
-# BUG: The new cluster_config has no "pems" key, so the filter has to be updated
-# to handle this case, pass data and still filter the "old_cluster_config" key.
 ORIGINAL = r"""
 {
     "token": "secret-token",
@@ -118,7 +118,6 @@ ORIGINAL = r"""
 }"""
 
 # Same as original, but with passwords and private data replaced by: "REMOVED"
-# BUG: "secret-token" has to be replaced by "REMOVED"
 EXPECTED = r"""{
     "token": "REMOVED",
     "cluster_config": {
@@ -196,21 +195,63 @@ def assert_filter_xapi_clusterd_db(bugtool, original, expected):
     # -------------------------------------------------------------------------
 
 
-def test_pems_blobs(isolated_bugtool):
-    """Assert that filter_xapi_clusterd_db() replaces pems.blobs strings"""
+def test_removal_of_all_secrets(isolated_bugtool):
+    """Assert that filter_xapi_clusterd_db() replaces all secrets in the db"""
     assert_filter_xapi_clusterd_db(isolated_bugtool, ORIGINAL, EXPECTED)
 
 
-# CA-358870: filter_xapi_clusterd_db: remove token from the report
-def test_remove_token(isolated_bugtool):
-    """CA-358870: Assert that filter_xapi_clusterd_db() removes the token"""
+def check_assert_on_unexpected_differences_in_output(bugtool, expected, diff):
+    """Self-test: Ensure that the assertion function asserts on unexpected output"""
 
-    # Load the expected output and remove the token from it
+    # -> Test setup:
+    #
+    # The expected output is modified to contain an unexpected token value
+    # that should cause the assertion function to fail.
+
+    # -> Act: Call the assertion function
+    with pytest.raises(AssertionError) as exc_info:
+        assert_filter_xapi_clusterd_db(bugtool, ORIGINAL, json.dumps(expected))
+
+    # -> Assert: Check that the assertion function failed on the unexpected output
+    #
+    # The assertion function should assert on the differing token value
+    # and the diff should be in the assertion error message
+
+    if diff not in exc_info.value.args[0]:  # pragma: no cover
+        print(exc_info.value.args)
+        pytest.fail("The assertion function did not assert on the unexpected output")
+
+
+def test_assertion_on_unexpected_token(isolated_bugtool):
+    """Self-test: Ensure that the assertion function asserts on unexpected token"""
+
+    # -> Test setup: Modify the expected output to contain an unexpected token value
+
     expected = json.loads(EXPECTED)
-    expected["token"] = "REMOVED"
-    expected_json = json.dumps(expected)
+    expected["token"] = "unexpected token value"
 
-    assert_filter_xapi_clusterd_db(isolated_bugtool, ORIGINAL, expected_json)
+    # -> Act and assert: Check that the assertion function fails on the unexpected output
+    #    The assertion function should assert on the differing authkey value and the
+    #    diff with the wrongly expected string should be in the assertion error message
+
+    diff = "{'token': 'REMOVED'} != {'token': 'unexpected token value'}"
+    check_assert_on_unexpected_differences_in_output(isolated_bugtool, expected, diff)
+
+
+def test_assertion_on_unexpected_authkey(isolated_bugtool):
+    """Self-test: Ensure that the assertion function asserts on unexpected authkey"""
+
+    # -> Test setup: Modify the expected output to contain an unexpected authkey value
+
+    expected = json.loads(EXPECTED)
+    expected["cluster_config"]["authkey"] = "unexpected authkey value"
+
+    # -> Act and assert: Check that the assertion function fails on the unexpected output
+    #    The assertion function should assert on the differing authkey value
+    #    and the wrongly expected string should be in the assertion error message
+
+    diff = "unexpected authkey value"
+    check_assert_on_unexpected_differences_in_output(isolated_bugtool, expected, diff)
 
 
 def test_no_authkey(isolated_bugtool):


### PR DESCRIPTION
`test_filter_xapi_clusterd_db.py`: Self-test asserting the expected output

The motivation for this PR is that I wanted to confirm that the clusterd secrets are really removed from the collected clusterd database data in the context of the question on another PR were we are looking at the clusterd on whether we can rely on the status-report to really safely filter the secrets in the cluster DB.

To double-check that we can rely on the checks in `test_filter_xapi_clusterd_db.py`, I reviewed them again to ensure that they work as required.

Changes:
- Merges test_pems_blobs() and test_remove_token() into test_removal_of_all_secrets()
- Adds new self-tests:
  - `test_assertion_on_unexpected_token()`       (Check assert on token that is not expected)
  - `test_assertion_on_unexpected_authkey()`     (Check assert on authkey that is not expected)
  
  These verify that the common test function `assert_filter_xapi_clusterd_db()` really detect if the output is not filtered properly.