### PR TITLE
CP-48198: Fix running pytest on tests/integration in GitHub CI (with coverage)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-command_line = -m pytest --junitxml=.git/pytest.xml --cov-report=term-missing tests/unit
+command_line = -m pytest --junitxml=.git/pytest.xml --cov-report=term-missing
 # Default data file for "coverage run": Store coverage data in .git/.coverage
 data_file = .git/.coverage
 relative_files = True

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           if [ -f requirements.txt ]; then pip2 install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip2 install -r requirements-dev.txt; fi
-          pip2 install pylint==1.9.4
+          pip2 install pylint==1.9.4; sudo mkdir /opt/xensource # mountpoint for tests
 
       - name: Run pylint-1.9.4 for pylint --py3k linting (configured in .pylintrc)
         run: python2 -m pylint xen-bugtool
@@ -146,7 +146,7 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
-      - run: pip install -r requirements-dev.txt
+      - run: pip install -r requirements-dev.txt; sudo mkdir /opt/xensource
         name: Install the pytest dependencies for running the pytest suite using Python3
 
       - uses: actions/cache@v4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+"""tests/conftest.py: top-level pytest fixtures for testing xen-bugtool
+
+Introduction to fixtures:
+https://docs.pytest.org/en/8.0.x/fixture.html
+
+How to use fixtures:
+https://docs.pytest.org/en/8.0.x/how-to/fixtures.html
+
+The full documentation on fixtures:
+https://docs.pytest.org/en/8.0.x/reference/fixtures.html
+"""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def tests_dir():
+    """pytest fixture to provide the path to status-report/tests"""
+    return os.path.dirname(__file__)
+
+
+@pytest.fixture(scope="session")
+def bugtool_script(tests_dir):
+    """pytest fixture to provide the path to status-report/tests"""
+    return os.path.abspath(os.path.join(tests_dir, os.pardir, "xen-bugtool"))
+
+
+@pytest.fixture(scope="session")
+def mocks_dir(tests_dir):
+    """pytest fixture to provide the path to status-report/tests/mocks"""
+    return os.path.join(tests_dir, "mocks")
+
+
+@pytest.fixture(scope="session")
+def dom0_template(tests_dir):
+    """Fixture to provide the path to status-report/tests/integration/dom0-template"""
+    return os.path.join(tests_dir, "integration", "dom0-template")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,7 +24,7 @@ def create_and_enter_test_environment(mocks_dir):
 
     activate_private_test_namespace(
         BUGTOOL_DOM0_TEMPL,
-        ["/etc", "/opt", "/usr/sbin", "/usr/lib/systemd"],
+        ["/etc", "/opt/xensource", "/usr/sbin", "/usr/lib/systemd"],
     )
 
     # Add the mocks directory to the PYTHONPATH for sub-processes to find the mocks:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@ see README-pytest-chroot.md for an overview:
 from __future__ import print_function
 
 import os
+import sys
 
 import pytest
 
@@ -18,10 +19,18 @@ from .utils import BUGTOOL_DOM0_TEMPL, BUGTOOL_OUTPUT_DIR, run
 
 
 @pytest.fixture(autouse=True, scope="session")
-def create_and_enter_test_environment():
+def create_and_enter_test_environment(mocks_dir):
     """Activate a namespace with bind mounts for testing xen-bugtool"""
-    activate_private_test_namespace(BUGTOOL_DOM0_TEMPL, ["/etc", "/opt", "/usr/sbin", "/usr/lib/systemd"])
-    os.environ["PYTHONPATH"] = "tests/mocks"
+
+    activate_private_test_namespace(
+        BUGTOOL_DOM0_TEMPL,
+        ["/etc", "/opt", "/usr/sbin", "/usr/lib/systemd"],
+    )
+
+    # Add the mocks directory to the PYTHONPATH for sub-processes to find the mocks:
+    os.environ["PYTHONPATH"] = mocks_dir
+    # Add the mocks directory to the sys.path for the current process to find the mocks:
+    sys.path.insert(0, mocks_dir)
 
 
 # zip, tar, tar.bz2 are the three output formats supported by xen_bugtool:

--- a/tests/integration/test_system_load.py
+++ b/tests/integration/test_system_load.py
@@ -11,7 +11,7 @@ from .utils import (
 
 # In this test case we need to sleep for 1 sec, and it is sufficient
 # to test to only with zip archives to keep the test duration short:
-def test_system_load(output_archive_type="zip"):
+def test_system_load(bugtool_script, output_archive_type="zip"):
     """Test xen-bugtool --entries=system-load"""
 
     entry = "system-load"
@@ -30,7 +30,7 @@ def test_system_load(output_archive_type="zip"):
         sar.write("#!/bin/sh\nsleep 1;cat /etc/xensource-inventory\n")
     os.chmod("/var/sar", 0o777)  # nosec
 
-    run_bugtool_entry(output_archive_type, entry)
+    run_bugtool_entry(bugtool_script, output_archive_type, entry)
 
     assert_content_from_dom0_template("sar-A.out", "etc/xensource-inventory")
     assert_file("var/log/sa/sa01", "sa01 test data")

--- a/tests/integration/test_xenserver_config.py
+++ b/tests/integration/test_xenserver_config.py
@@ -10,14 +10,14 @@ from .utils import (
 )
 
 
-def test_xenserver_config(output_archive_type):
+def test_xenserver_config(bugtool_script, output_archive_type):
     """
     Run xen-bugtool --entries=xenserver-config in test jail
     (created by auto-fixtures, see README-pytest-chroot.md)
     """
     entry = "xenserver-config"
 
-    run_bugtool_entry(output_archive_type, entry)
+    run_bugtool_entry(bugtool_script, output_archive_type, entry)
 
     # Check the output of xen-bugtool --entries=xenserver-config:
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -19,7 +19,7 @@ else:
     from subprocess import getstatusoutput
 
 BUGTOOL_OUTPUT_DIR = "/var/opt/xen/bug-report/"
-BUGTOOL_DOM0_TEMPL = "tests/integration/dom0-template/"
+BUGTOOL_DOM0_TEMPL = os.path.join(os.path.dirname(__file__), "dom0-template")
 
 
 def run(command):
@@ -78,7 +78,7 @@ def assert_content_from_dom0_template(path, control_path=None):
     """Check the given path against the files from the test's Dom0 template"""
 
     assert path[0] != "/"  # We expect a relative path in the report archive
-    control = BUGTOOL_DOM0_TEMPL + (control_path or path)
+    control = os.path.join(BUGTOOL_DOM0_TEMPL, (control_path or path))
     print(control)
     if os.path.isdir(path):
         # path is a directory, compare it recursively using dircmp():
@@ -126,7 +126,7 @@ def extract(zip_or_tar_archive, archive_type):  # pragma: no cover
     os.unlink(zip_or_tar_archive)
 
 
-def run_bugtool_entry(archive_type, test_entries):
+def run_bugtool_entry(bugtool_script, archive_type, test_entries):
     """
     Execute the bugtool script with the given entries and prepare testing it.
 
@@ -150,8 +150,6 @@ def run_bugtool_entry(archive_type, test_entries):
     if error_code:
         raise RuntimeError(output)
 
-    src_dir = os.getcwd()
-
     #
     # Switch to the BUGTOOL_OUTPUT_DIR and extract the bugball in it.
     #
@@ -166,9 +164,7 @@ def run_bugtool_entry(archive_type, test_entries):
     os.chdir(test_entries)
 
     # Validate the extracted inventory.xml using the XML schema from the test framework:
-    with open(src_dir + "/tests/integration/inventory.xsd") as xml_schema:
+    with open(os.path.join(os.path.dirname(__file__), "inventory.xsd")) as xml_schema:
         XMLSchema(parse(xml_schema)).assertValid(parse("inventory.xml"))
         # Remove valid inventory.xml (not removed files will make the tests fail):
         os.unlink("inventory.xml")
-    # Add a symlink, so assert_content_from_dom0_template() can find the tests:
-    os.symlink(src_dir + "/tests", "tests")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -42,12 +42,6 @@ def testdir():
 
 
 @pytest.fixture(scope="session")
-def dom0_template(testdir):
-    """Test fixture to get the directory of the dom0 template"""
-    return testdir + "/../integration/dom0-template"
-
-
-@pytest.fixture(scope="session")
 def imported_bugtool(testdir, dom0_template):
     """Fixture to provide the xen-bugtool script as a module for unit tests"""
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -249,7 +249,10 @@ def assert_bugtool_logfile_data(logfile):
     # caught and logged, the log file should contain the backtrace from the
     # raised exception:
     #
-    assert len(lines) == 9
+    if sys.version_info >= (3, 11):  # pragma: no cover
+        assert len(lines) == 10  # Python 3.11+ includes a new line in the backtrace
+    else:
+        assert len(lines) == 9
     for backtrace_string in MOCK_EXCEPTION_STRINGS:
         assert backtrace_string in log
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -33,7 +33,8 @@ ETC_PASSWD = "/etc/passwd"
 def assert_valid_inventory_schema(inventory_tree):
     """Assert that the passed inventory validates against the inventory schema"""
 
-    with open(os.getcwd() + "/tests/integration/inventory.xsd") as xml_schema:
+    inventory_schema = os.path.dirname(__file__) + "/../integration/inventory.xsd"
+    with open(inventory_schema) as xml_schema:
         XMLSchema(parse(xml_schema)).assertValid(inventory_tree)
 
 


### PR DESCRIPTION
## This PR includes a number of fixes / improvements for the tests:

### Improve tests so that tests/integration/*.py can contribute to covering xen-bugtool
- [`.github/workflows/main.yml`](https://github.com/xenserver/status-report/pull/105/files#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3):
  - Fix running `tests/integration` in GitHub CI which use `/opt/hostedtoolcache` to provide Python.
  - Therefore, `tests/integration` needs to use `/opt/xensource` as mount point for the dom0 template files in `/opt/xensource`.
- [`tests/integration/utils.py`](https://github.com/xenserver/status-report/pull/105/files#diff-d9e46323e51c9f9cfa4c9fa1acc40a8cc931da3ba7f82f6867360507590cc671): Use `runpy.run_path(bugtool_script, run_name="__main__")` to get coverage if the script
- [`tests/integration/conftest.py`](https://github.com/xenserver/status-report/pull/105/files#diff-c87c5173e88bb0f60b00107f4586304f4869a976a4f998425efe3481c0db9f56): Add mocks to `sys.path` so the mocks are found during `runpy.run_path()`
- [`.coveragerc`](https://github.com/xenserver/status-report/pull/105/files#diff-834e9b406d74791ffbafaeec9cc894082cea9739bc347b6ff9f72312c92ebc79): Update to no longer limit coverage to `tests/unit` but also include `tests/integration`.

### Support running tests independent of the starting directory
- Fix places where `os.getcwd()` was used to get relative paths to be based on `__file__`.
- Pass path names to functions wherever this is feasible

### Other changes
- [`tests/unit/test_main.py`](https://github.com/xenserver/status-report/pull/105/files#diff-0869a95c81274e80bbb8fdf331b968d82948d5c57af75d92048cc25ee20f5213): Fix test to pass with Python 3.11