### PR TITLE
CA-392459: Avoid opening /dev/mem when calling biosdevname

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,8 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz
-          ./coveralls --service-name=github
+          cp .git/coverage27.xml coverage.xml
+          ./coveralls --service-name=github --format=cobertura
 
   pre-commit:
     name: "Python3: Pre-Commit Suite"

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1053,7 +1053,7 @@ exclude those logs from the archive.
     cmd_output(CAP_NETWORK_STATUS, [EBTABLES, '-L'])
     cmd_output(CAP_NETWORK_STATUS, [IPTABLES, '-nvL'])
     cmd_output(CAP_NETWORK_STATUS, [BRCTL, 'show'])
-    cmd_output(CAP_NETWORK_STATUS, [BIOSDEVNAME, '-d'])
+    cmd_output(CAP_NETWORK_STATUS, [BIOSDEVNAME, '-d', '-x'])
     for p in os.listdir('/sys/class/net/'):
         if os.path.isdir('/sys/class/net/%s/bridge' % p):
             cmd_output(CAP_NETWORK_STATUS, [BRCTL, 'showmacs', p])


### PR DESCRIPTION
biosdevname opens /dev/mem to read the $PIR PCI interrupt routing table. This fails with Secure Boot enabled and causes a warning in the kernel. log. Since the $PIR PCI interrupt routing table is used for routing PCI interrupts to ISA IRQs, it is not useful on any modern system so pass "-x" to biosdevname to avoid this behaviour.