### PR TITLE
CP-49659: Test `modinfo` returning non-ASCII characters and fix the triggered error

### DIFF
--- a/tests/integration/dom0-template/usr/sbin/modinfo
+++ b/tests/integration/dom0-template/usr/sbin/modinfo
@@ -1,2 +1,19 @@
 #!/bin/sh
-echo "modinfo for $*"
+if [ "$1" = dell_smbios ]; then
+    # This is the real output for dell-smbios that contains an UTF-8 character
+    echo "\
+filename:       /lib/modules/6.6.22+0/kernel/drivers/platform/x86/dell/dell-smbios.ko
+license:        GPL
+description:    Common functions for kernel modules using Dell SMBIOS
+author:         Mario Limonciello <mario.limonciello@outlook.com>
+author:         Pali Rohár <pali@kernel.org>
+author:         Gabriele Mazzotta <gabriele.mzt@gmail.com>
+author:         Matthew Garrett <mjg@redhat.com>
+srcversion:     CBEF13F3C192A771A462239
+alias:          wmi:A80593CE-A997-11DA-B012-B622A1EF5492
+depends:        dell-wmi-descriptor,dcdbas,wmi
+retpoline:      Y
+intree:         Y
+name:           dell_smbios
+vermagic:       6.6.22+0 SMP mod_unload modversions"
+fi

--- a/tests/unit/test_process_output.modules
+++ b/tests/unit/test_process_output.modules
@@ -1,3 +1,1 @@
-tcp_diag 16384 0 - Live 0xffffffffc05c0000
-udp_diag 16384 0 - Live 0xffffffffc059c000
-inet_diag 24576 2 tcp_diag,udp_diag, Live 0xffffffffc0533000
+dell_smbios 32768 0 - Live 0xffffffffc0779000

--- a/tests/unit/test_process_output.py
+++ b/tests/unit/test_process_output.py
@@ -1,5 +1,7 @@
 """Regression tests for the bugtool helper function mdadm_arrays()"""
 
+import pytest
+
 
 def test_mdadm_arrays(bugtool, dom0_template):
     """Assert mdadm_arrays() returning arrays dom0_template/usr/sbin/mdadm"""
@@ -7,13 +9,30 @@ def test_mdadm_arrays(bugtool, dom0_template):
     assert list(bugtool.mdadm_arrays()) == ["/dev/md0", "/dev/md1"]
 
 
+@pytest.mark.xfail("True", reason="Python2 decode() fails with UTF-8: remove it next")
 def test_module_info(bugtool, dom0_template):
     """Assert module_info() returning module names from test_module_info.modules"""
 
     bugtool.PROC_MODULES = __file__.replace(".py", ".modules")
     bugtool.MODINFO = dom0_template + "/usr/sbin/modinfo"
-    output = bugtool.module_info(bugtool.CAP_KERNEL_INFO)
-    assert output == "modinfo for tcp_diag\nmodinfo for udp_diag\nmodinfo for inet_diag\n"
+    # Expect bytes containing the UTF-8 sequence \xc3\xa1 in the names of the authors
+    expected = b"""\
+filename:       /lib/modules/6.6.22+0/kernel/drivers/platform/x86/dell/dell-smbios.ko
+license:        GPL
+description:    Common functions for kernel modules using Dell SMBIOS
+author:         Mario Limonciello <mario.limonciello@outlook.com>
+author:         Pali Roh\xc3\xa1r <pali@kernel.org>
+author:         Gabriele Mazzotta <gabriele.mzt@gmail.com>
+author:         Matthew Garrett <mjg@redhat.com>
+srcversion:     CBEF13F3C192A771A462239
+alias:          wmi:A80593CE-A997-11DA-B012-B622A1EF5492
+depends:        dell-wmi-descriptor,dcdbas,wmi
+retpoline:      Y
+intree:         Y
+name:           dell_smbios
+vermagic:       6.6.22+0 SMP mod_unload modversions
+"""
+    assert bugtool.module_info(bugtool.CAP_KERNEL_INFO) == expected
 
 
 def test_multipathd_topology(bugtool, dom0_template):

--- a/tests/unit/test_process_output.py
+++ b/tests/unit/test_process_output.py
@@ -1,7 +1,5 @@
 """Regression tests for the bugtool helper function mdadm_arrays()"""
 
-import pytest
-
 
 def test_mdadm_arrays(bugtool, dom0_template):
     """Assert mdadm_arrays() returning arrays dom0_template/usr/sbin/mdadm"""
@@ -9,7 +7,6 @@ def test_mdadm_arrays(bugtool, dom0_template):
     assert list(bugtool.mdadm_arrays()) == ["/dev/md0", "/dev/md1"]
 
 
-@pytest.mark.xfail("True", reason="Python2 decode() fails with UTF-8: remove it next")
 def test_module_info(bugtool, dom0_template):
     """Assert module_info() returning module names from test_module_info.modules"""
 

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1671,7 +1671,7 @@ def module_info(cap):
 
     run_procs([procs])
 
-    return output.getvalue().decode()
+    return output.getvalue()
 
 
 def multipathd_topology(cap):


### PR DESCRIPTION
Fix CP-49659:
- Test `modinfo` returning non-ASCII characters and
- fix the error triggered by it.

XS8: If these kernel modules are loaded, the bugtool file modinfo.out is broken:
```js
bq2415x_charger bq2415x charger driver
cb710           ENE CB710 memory card reader driver
cb710-mmc       ENE CB710 memory card reader driver
cdc_mbim        USB CDC MBIM host driver              (for MBIM Mobile broadband modems)
dell-smm-hwmon  Dell laptop SMM BIOS hwmon driver     (for Dell Laptops)
gl520sm         GL520SM driver                        (I2C temperature/voltage Sensor)
i2c-via         i2c for Via vt82c586b southbridge     (Via Chipsets)
nf_dup_ipv4     nf_dup_ipv4: Duplicate IPv4 packet
nf_dup_ipv6     nf_dup_ipv6: IPv6 packet duplication
nft_socket      nf_tables socket match module
nft_tproxy      nf_tables tproxy support module
qmi_wwan        Qualcomm MSM Interface (QMI) WWAN driver
ums-isd200      Driver for In-System Design, Inc. ISD200 ASIC
via686a         VIA 686A Sensor device               (I2C temperature/voltage Sensor)
xt_TEE          Xtables: Reroute packet copy
```
That means it should only happen if the server uses one of the two I2C sensors or the `cb710`, or the customer sets up very specific network filtering rules manually in Dom0.

In these rare cases, the issue surfaces by the bugtool file `modinfo.out` having this content:
```py
Traceback (most recent call last):
  File "./xen-bugtool", line 733, in collect_data
    s = no_unicode(v["func"](cap))
  File "./xen-bugtool", line 1640, in module_info
    return output.getvalue().decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 48009: ordinal not in range(128)
```
Reproduced by loading one of the kernel modules using:
```py
modprobe cb710
xen-bugtool -y --entries=kernel-info
```
This command would gather data to diagnose the trigger in a specific case:
```py
modinfo `cut -d' ' -f1 /proc/modules` >modinfo.out
```
Script to produce or confirm the list of kernel modules triggering this issue on such kernel:
```bash
find /usr/lib -name *.ko | sed -n 's|.*/||;s/.ko//p'|xargs modinfo >modinfo.out
for i in `grep -P '([^\x00-\x7F]|filename)' modinfo.out|grep -B1 -P '([^\x00-\x7F])'|sed -n 's|.*/||;s/.ko//p'|sort`;do printf %-16.16s $i;modinfo -d $i;done
```
