### PR TITLE
pytest: Add support for pytest-8.2 on Python3.11 (color, verbose)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,9 @@
 [pytest]
-# By default, show reports for failed tests:
-addopts=-rF
+# By default, show reports for failed tests, and show the summary: -rF
+# By default, also be verbose (needed for self-tests with pytest-8) -vv
+# By default, also show the local variables in the traceback: --showlocals
+addopts=-rF -vv --showlocals
+
 # imp is only used in a unit test, will be updated to python3 later:
 filterwarnings=ignore:the imp module is deprecated
 # Enable live logging of the python log output, starting with log level INFO by default:

--- a/tests/unit/test_filter_xapi_clusterd_db.py
+++ b/tests/unit/test_filter_xapi_clusterd_db.py
@@ -168,8 +168,13 @@ def test_assertion_on_unexpected_token(isolated_bugtool):
     # -> Act and assert: Check that the assertion function fails on the unexpected output
     #    The assertion function should assert on the differing authkey value and the
     #    diff with the wrongly expected string should be in the assertion error message
+    #
+    # pytest-8 adds very fine-grained coloring of the assertion error message
+    # which makes it harder to match the diff string in the assertion error message.
+    # Apparently, we cannot disable the coloring for a single assertion, so we can
+    # only check for the the unexpected token in the assertion:
 
-    diff = "{'token': 'REMOVED'} != {'token': 'unexpected token value'}"
+    diff = "'token': 'unexpected token value'"
     check_assert_on_unexpected_differences_in_output(isolated_bugtool, expected, diff)
 
 


### PR DESCRIPTION
Update support for testing using pytest:
Add support for pytest-8.2 on Python3.11 (color, verbose)

This change supports the different assertion diagnostic output that pytest-8 produces:

The assertions from pytest-8 include escape sequences for colouring the output nicely, and to pass both, the string that we expect to find in the assertion needs to be shorter.

For pytest v8 to produce the assertion messages that this test expects, we need to add `-vv` to the default pytest options to enable more verbose assertion messages. 

By default, also show the local variables in the traceback of an test exception: Add `--showlocals` to the default options.