### PR TITLE
CA-394409: plugins: Fix multiple file patterns for the same directory

### DIFF
--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -104,6 +104,7 @@ init
 initialisation
 initialised
 initiatorname
+inotify
 iomem
 ioports
 iscsi

--- a/tests/integration/dom0-template/etc/xensource/bugtool/mock/stuff.xml
+++ b/tests/integration/dom0-template/etc/xensource/bugtool/mock/stuff.xml
@@ -3,6 +3,34 @@
 <files>/etc/passwd</files>
 <files>/etc/group</files>
 <files>/proc/self/status</files>
+
+<!--
+Test that multiple patterns work together and both are collected.
+
+Two patterns for the same directory, and each pattern matches one file:
+- the 1st pattern is negated and matches the file max_queued_events
+- the 2nd pattern matches the file max_user_instances:
+-->
+<directory pattern=".*user_.*" negate="yes">/proc/sys/fs/inotify</directory>
+<directory pattern=".*max_user_instances.*">/proc/sys/fs/inotify</directory>
+<!--
+Expected result, asserted by tests/unit/test_output.py:
+- 1st entry: /proc/sys/fs/inotify/max_queued_events
+- 2nd entry: /proc/sys/fs/inotify/max_user_instances
+-->
+
+<!--
+Test that the 2nd directory pattern does not affect the first directory pattern,
+even when it matches no file:
+- the 1st pattern matches the file /proc/sys/fs/epoll/max_user_watches
+- the 2nd pattern matches no file
+-->
 <directory pattern=".*ax_user_watches">/proc/sys/fs/epoll</directory>
+<directory pattern="no" negate="false">/proc/sys/fs/epoll</directory>
+<!--
+Expected result, asserted by tests/unit/test_output.py:
+- /proc/sys/fs/epoll/max_user_watches
+-->
+
 <command label="proc_version">cat /proc/version</command>
 </collect>

--- a/tests/unit/test_load_plugins.py
+++ b/tests/unit/test_load_plugins.py
@@ -50,8 +50,25 @@ def test_load_plugins(bugtool, dom0_template):
             "filter": None,
         },
     }
+
+    # Assert the tree_output entries for /proc/sys/fs/inotify:
+    entry_one, entry_two = bugtool.directory_specifications["/proc/sys/fs/inotify"]
+    cap, regex, negate = entry_one
+    assert cap == "mock"
+    assert regex.pattern == ".*user_.*"
+    assert negate
+    cap, regex, negate = entry_two
+    assert cap == "mock"
+    assert regex.pattern == ".*max_user_instances.*"
+    assert not negate
+
     # Assert the tree_output entry for /proc/sys/fs/epoll:
-    cap, regex, negate = bugtool.directory_specifications["/proc/sys/fs/epoll"]
+    entry_one, entry_two = bugtool.directory_specifications["/proc/sys/fs/epoll"]
+    cap, regex, negate = entry_one
     assert cap == "mock"
     assert regex.pattern == ".*ax_user_watches"
+    assert not negate
+    cap, regex, negate = entry_two
+    assert cap == "mock"
+    assert regex.pattern == "no"
     assert not negate

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -50,6 +50,8 @@ def assert_mock_bugtool_plugin_output(temporary_directory, subdir, names):
         subdir + "/ls-l-%etc.out",
         subdir + "/proc/self/status",
         subdir + "/proc/sys/fs/epoll/max_user_watches",
+        subdir + "/proc/sys/fs/inotify/max_queued_events",
+        subdir + "/proc/sys/fs/inotify/max_user_instances",
         subdir + "/proc_version.out",
     ]
     assert sorted(names) == expected_names

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -602,7 +602,10 @@ def file_output(cap, path_list):
 
 def tree_output(cap, path, pattern = None, negate = False):
     if cap in entries:
-        directory_specifications[path] = (cap, pattern, negate)
+        if path in directory_specifications:
+            directory_specifications[path].append((cap, pattern, negate))
+        else:
+            directory_specifications[path] = [(cap, pattern, negate)]
 
 
 def traverse_directory_specifications(directory_specs, requested_capabilities):
@@ -611,13 +614,15 @@ def traverse_directory_specifications(directory_specs, requested_capabilities):
     :param directory_specs: Directories to lookup with cap, pattern, and negate.
     :param requested_capabilities: The list of requested capabilities.
     """
-    for directory, directory_items in directory_specs.items():
-        # Unpack the stored capability, pattern and negate flag of each row:
-        capability, pattern, negate = directory_items
-        # If the capability is in the requested inventory entries, check it:
-        if capability in requested_capabilities:
-            if os.path.isdir(directory):
-                lookup_tree_recursively(capability, directory, pattern, negate)
+    for directory, tree_output_entries in directory_specs.items():
+        # Multiple tree_output calls may have appended multiple output entries:
+        for directory_items in tree_output_entries:
+            # Unpack the stored capability, pattern and negate flag of each row:
+            capability, pattern, negate = directory_items
+            # If the capability is in the requested inventory entries, check it:
+            if capability in requested_capabilities:
+                if os.path.isdir(directory):
+                    lookup_tree_recursively(capability, directory, pattern, negate)
 
 
 def lookup_tree_recursively(cap, path, pattern, negate):


### PR DESCRIPTION
## CA-394409: Fix collecting logfiles of auto-cert-kit and tapdisk-logs:

- Fix multiple file patterns for the same directory:
  - Append the directory specifications to a list instead of overwriting the previous directory spec.
```py
        if path in directory_specifications:
            directory_specifications[path].append((cap, pattern, negate))
        else:
            directory_specifications[path] = [(cap, pattern, negate)]
```
Then, when we loop over the directory_specifications, loop over the list of tree_output_entries:
```py
   for directory, tree_output_entries in directory_specs.items():
        # Multiple tree_output calls may have appended multiple output entries:
        for directory_items in tree_output_entries:
            # Unpack the stored capability, pattern and negate flag of each row:
            capability, pattern, negate = directory_items
```
When ignoring shifting the indendation to loop over the tree_output_entries, the change is small:
The output of `git log -w -p -n1 xen-bugtool` of the commit is:
```py
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -602,7 +602,10 @@ def file_output(cap, path_list):

 def tree_output(cap, path, pattern = None, negate = False):
     if cap in entries:
-        directory_specifications[path] = (cap, pattern, negate)
+        if path in directory_specifications:
+            directory_specifications[path].append((cap, pattern, negate))
+        else:
+            directory_specifications[path] = [(cap, pattern, negate)]


 def traverse_directory_specifications(directory_specs, requested_capabilities):
@@ -611,7 +614,9 @@ def traverse_directory_specifications(directory_specs, requested_capabilities):
     :param directory_specs: Directories to lookup with cap, pattern, and negate.
     :param requested_capabilities: The list of requested capabilities.
     """
-    for directory, directory_items in directory_specs.items():
+    for directory, tree_output_entries in directory_specs.items():
+        # Multiple tree_output calls may have appended multiple output entries:
+        for directory_items in tree_output_entries:
             # Unpack the stored capability, pattern and negate flag of each row:
             capability, pattern, negate = directory_items
             # If the capability is in the requested inventory entries, check it:
```
       
- Ensure that this works as expected by extending the tests accordingly.

### Change:

Fix this issue to collect logs from `tapdisk` and `auto-cert-kit` as expected.

### Details:

- At least three plugins collect files in /var/log using different file patterns: Auto_Cert_Kit, tapdisk-logs and xcp-rrdd-plugins.
- After merging CP-41238, only one pattern or directory tree collection was supported: Previous patterns were overwritten by plugins loaded after plugins loaded earlier.
  - Directory tree patterns added by plugins loaded earlier were overwritten by plugins loaded later.
  - As auto-cert-kit is not installed by default, this issue could only be noticed by missing tapdisk logs.

## Manual Verification Testing
```py
curl -Lo xen-bugtool.CP-49944 https://github.com/xenserver-next/status-report/raw/CP-49944-multiple-patterns-for-one-directory/xen-bugtool
chmod +x xen-bugtool.CP-49944
```
## DoD:
```bash
# mkdir /var/log/blktap
# touch /var/log/blktap/logfile.log
XENRT_BUGTOOL_BASENAME=bugtool ./xen-bugtool.CP-49944 -y --entries=tapdisk-logs,xcp-rrdd-plugins
# tar tf /var/opt/xen/bug-report/bugtool.tar.bz2|grep -e 'log$' -e blktap
bugtool/var/log/blktap/logfile.log
bugtool/var/log/xcp-rrdd-plugins.log
```
and likewise, for when auto-cert-kit is installed for:
```bash
# yum install auto-cert-kit 
# touch bugtool/var/log/auto-cert-kit{-plugin}.log
# XENRT_BUGTOOL_BASENAME=bugtool ./xen-bugtool.CP-49944 -y --entries=Auto_Cert_Kit
# tar tf /var/opt/xen/bug-report/bugtool.tar.bz2|grep -e 'log$'
bugtool/var/log/auto-cert-kit.log
bugtool/var/log/auto-cert-kit-plugin.log
```