### PR TITLE
Prepare `release/yangtze` for backporting #51 (collect up-to-date RRDs)

### DIFF
--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -20,6 +20,7 @@ def assert_mock_bugtool_plugin_output(temporary_directory, subdir, names):
     expected_names = [
         subdir + "/etc/group",
         subdir + "/etc/passwd.tar",
+        subdir + "/inventory.xml",
         subdir + "/ls-l-%etc.out",
         subdir + "/proc/self/status",
         subdir + "/proc/sys/fs/epoll/max_user_watches",
@@ -30,6 +31,7 @@ def assert_mock_bugtool_plugin_output(temporary_directory, subdir, names):
     extracted = "%s/%s/" % (temporary_directory, subdir)
 
     # Will be refactored to be more easy in a separate commit soon:
+    assert_valid_inventory_schema(parse(extracted + "inventory.xml"))
     with open(extracted + "proc_version.out") as proc_version:
         assert proc_version.read()[:14] == "Linux version "
     with open(extracted + "ls-l-%etc.out") as etc:
@@ -52,7 +54,7 @@ def assert_mock_bugtool_plugin_output(temporary_directory, subdir, names):
 
 
 def minimal_bugtool(bugtool, dom0_template, archive, subdir, mocker):
-    """Load the plugins from dom0_template and collect the specified data"""
+    """Load the plugins from the template and include the generated inventory"""
 
     mocker.patch("xen-bugtool.time.strftime", return_value="time.strftime")
     # Load the mock plugin from dom0_template and process the plugin's caps:
@@ -65,6 +67,7 @@ def minimal_bugtool(bugtool, dom0_template, archive, subdir, mocker):
     # Mock the 2nd argument of the ls -l /etc to collect it using dom0_template:
     bugtool.data["ls -l /etc"]["cmd_args"][2] = dom0_template + "/etc"
     bugtool.collect_data(subdir, archive)
+    bugtool.include_inventory(archive, subdir)
     archive.close()
 
 

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -556,6 +556,13 @@ def func_output(cap, label, func):
     if cap in entries:
         data[label] = {'cap': cap, 'func': func}
 
+
+def include_inventory(archive, subdir):
+    inventory = {'cap': None, 'output': StringIOmtime(no_unicode(make_inventory(data, subdir)))}
+    archive.add_path_with_data(construct_filename(subdir, 'inventory.xml', inventory),
+                StringIOmtime(no_unicode(make_inventory(data, subdir))))
+
+
 def collect_data(subdir, archive):
     process_lists = {}
 
@@ -1183,9 +1190,7 @@ exclude those logs from the archive.
     collect_data(subdir, archive)
 
     # include inventory
-    inventory = {'cap': None, 'output': StringIOmtime(no_unicode(make_inventory(data, subdir)))}
-    archive.add_path_with_data(construct_filename(subdir, 'inventory.xml', inventory),
-                StringIOmtime(no_unicode(make_inventory(data, subdir))))
+    include_inventory(archive, subdir)
 
     if archive.close():
         res = 0


### PR DESCRIPTION
## Minor backport for `release/yangtze`:

This pull request backports a minor improvement from `master` to `release/yangtze`:

It backports a minimal part of https://github.com/xenserver/status-report/pull/33/commits/62601dba1540565431275fbf2efd6e9efb7122c6 from #33 to `release/yangtze`.


This provides the correct base code for backporting the collection of up-to-date RRDs to `release/yangtze` by backporting #51 (and #88, #115, and #82 see below).

### Description
Refactor the tests in `test_output.py` by extracting the `include_inventory()` function into a separate definition. 

Additionally, update `tests/unit/test_output.py` to test the `inventory.xml` generated by the extracted function in isolation.
 
These changes improve the organization, testability and readability of the code.

----
The PR that would be backported based on this PR would be:
- #51

These fixes for side effects of #51 would be needed as well:
- #88
- #115
- #82

PS: See #120 for an initial attempt of these backports that included a backport of #51 and #115, but was not based on the latests fixes in `release/yangtze` and did not include the needed backports of #88 and #82.
