### PR TITLE
Yangtze: Cherry-Pick "Add scsi disk provisioning mode" from @MarkSymsCtx

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -921,6 +921,8 @@ exclude those logs from the archive.
     func_output(CAP_DISK_INFO, 'scsi-hosts', dump_scsi_hosts)
     cmd_output(CAP_DISK_INFO, [LVDISPLAY, '--map'])
     cmd_output(CAP_BLOCK_SCHEDULER, [LSBLK, '-io', 'type,name,sched,tran,rota,log-sec,rq-size,vendor,model'], label='lsblk')
+    file_output(CAP_DISK_INFO, ['/sys/block/sd*/device/scsi_disk/*/provisioning_mode',
+                                '/sys/block/sd*/device/scsi_disk/*/thin_provisioning'])
 
     # mdadm information
     cmd_output(CAP_DISK_INFO, [MDADM, '--detail-platform'])


### PR DESCRIPTION
This is a backport of #119 by @MarkSymsCtx to the Yangtze release branch for the next user-space hotfix for 8.2.1: 

This pull request cherry-picks PR #119 by @MarkSymsCtx for collecting the SCSI disk provisioning mode of SCSI disks.

It collects provisioning mode from the `/sys/block/sd*/device/scsi_disk/*/provisioning_mode` files.
This information is useful for managing and monitoring storage devices.