### PR TITLE
Backport for Yangtze: Fix unclosed file objects in TarOutput

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1812,7 +1812,8 @@ class TarSubArchive(io.BytesIO):
         :param name: Recorded path of the the file in the tar archive for extraction
         :param filename: Real file name of the file to be added to the tar archive
         """
-        self.file.addfile(self.file.gettarinfo(filename, name), open(filename, "rb"))
+        with open(filename, "rb") as buffered_reader:
+            self.file.addfile(self.file.gettarinfo(filename, name), buffered_reader)
 
 class ArchiveWithTarSubarchives(object):
     """Base class for TarOutput and ZipOutput with support to create sub-archives"""
@@ -1877,7 +1878,9 @@ class TarOutput(ArchiveWithTarSubarchives):
         s = os.stat(filename)
         ti.mtime = s.st_mtime
         ti.size = s.st_size
-        self.tf.addfile(ti, file(filename,'rb'))
+        with open(filename, "rb") as buffered_reader:
+            self.tf.addfile(ti, buffered_reader)
+
 
     def add_path_with_data(self, name, data):  # type:(str, StringIOmtime) -> None
         ti = self._getTi(name)


### PR DESCRIPTION
Backport to the Yangtze release branch:

Fix unclosed file objects when tar files are created, like when /etc/systemd.tar is created and collected(systemd units) and when `--output` is used to output to tar files.

This pull request fixes an issue in the TarOutput class where file objects were not being closed properly.

The fix involves using context managers to ensure that the file objects are closed after they are read.

This fix reduces memory usage and may improve the performance of the xen-bugtool / xenserver-status-report process in case tarballs instead of ZIP files are used as output format.