### PR TITLE
CA-399631: Increase the max size of xenserver-config for bug-tool

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -468,7 +468,7 @@ cap(CAP_XAPI_SUBPROCESS,     PII_NO,                    max_size=5*KB,
 cap(CAP_XEN_BUGTOOL,         PII_NO,    min_size=0)
 cap(CAP_XENRT,               PII_NO,    min_size=0,     max_size=500*MB,
     checked=False, hidden=True)
-cap(CAP_XENSERVER_CONFIG,    PII_MAYBE,                 max_size=80*KB,
+cap(CAP_XENSERVER_CONFIG,    PII_MAYBE,                 max_size=160*KB,
     max_time=10)
 cap(CAP_XENSERVER_DOMAINS,   PII_NO,                    max_size=1*KB,
     max_time=10)


### PR DESCRIPTION
Fix this issue:
Omitting /etc/systemd/user/dbus.service, size constraint of xenserver-config exceeded Omitting /etc/systemd/user/basic.target.wants/systemd-tmpfiles-setup.service, size constraint of xenserver-config exceeded

Tested: 4243304 NRPE
