### PR TITLE
cmd_output(): Check if the command is executable before planning to run it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -272,4 +272,15 @@ jobs:
         env:
           COVERALLS_FLAG_NAME: ${{ format('python{0}', steps.python.outputs.python-version ) }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pip install coveralls && coveralls --service=github && coveralls --finish || true
+        run: pip install coveralls && coveralls --service=github
+
+
+  finish-coverage-upload:
+    if: github.actor != 'nektos/act'
+    needs: [python2-tests, pre-commit]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finish the coverage upload to Coveralls
+        uses: coverallsapp/github-action@v1
+        with:
+          parallel-finished: true

--- a/tests/integration/dom0-template/etc/xensource/bugtool/mock/stuff.xml
+++ b/tests/integration/dom0-template/etc/xensource/bugtool/mock/stuff.xml
@@ -32,5 +32,6 @@ Expected result, asserted by tests/unit/test_output.py:
 - /proc/sys/fs/epoll/max_user_watches
 -->
 
-<command label="proc_version">cat /proc/version</command>
+<command label="proc_version">/usr/sbin/cat /proc/version</command>
+<command label="cover_branch">/usr/sbin/This command doesn't exist</command>
 </collect>

--- a/tests/unit/test_cmd_output.py
+++ b/tests/unit/test_cmd_output.py
@@ -1,0 +1,52 @@
+"""tests/unit/test_cmd_output.py: Unit-Test bugtool.cmd_output()"""
+
+
+def test_cmd_output(bugtool):
+    """Test all code lines in bugtool.cmd_output(cap, args, label, filter)"""
+
+    # Arguments for the positive test:
+    cap = bugtool.CAP_XENSERVER_CONFIG
+
+    # Assert that mismatching cap causes no output in bugtool.data:
+    bugtool.entries = [bugtool.CAP_DISK_INFO, cap, bugtool.CAP_PAM]
+    bugtool.cmd_output(cap=bugtool.CAP_XENSERVER_LOGS, args=[])
+    assert bugtool.data == {}
+
+    # Assert that non existing command results in no bugtool.data:
+    bugtool.cmd_output(cap=cap, args=["/nonexisting-command", "arg1", "arg2"])
+    assert bugtool.data == {}
+
+    # Assert matching cap and args produces expected_data
+    args = ["ls", "-l", __file__]
+    for command in [args, " ".join(args), "/nonexisting-command arg"]:
+        for label in [None, "cmd_output_label"]:
+            # cmd_output() does not call the filter function, just stores it
+            def mock():
+                return ""
+
+            mock()  # Cover the dummy filter function
+            bugtool.data = {}  # Reset bugtool.data for the next test
+            bugtool.cmd_output(cap=cap, args=command, label=label, filter=mock)
+
+            if command == "/nonexisting-command arg":
+                # Non-existing command produces no output
+                assert bugtool.data == {}
+            else:
+                # Existing command produces expected output
+
+                # Determine the expected label
+                if label:
+                    expected_label = label
+                elif isinstance(command, str):
+                    expected_label = command
+                else:
+                    expected_label = " ".join(command)
+
+                expected_data = {
+                    expected_label: {
+                        "filter": mock,
+                        "cap": bugtool.CAP_XENSERVER_CONFIG,
+                        "cmd_args": command,
+                    }
+                }
+                assert bugtool.data == expected_data

--- a/tests/unit/test_load_plugins.py
+++ b/tests/unit/test_load_plugins.py
@@ -2,7 +2,13 @@
 
 
 def test_load_plugins(bugtool, dom0_template):
-    """Assert () returning arrays of the  in the dom0-template"""
+    """
+    Assert the arrays expected by loading the mock plugin of the unit tests
+
+    To cover all lines of the new function is_deemed_executable(),
+    this test now calls the mock usr/sbin/cat in the dom0-template
+    using the absolute path it has inside of the dom0-template.
+    """
 
     # Use the plugins found in the dom0_template "/etc/xensource/bugtool":
     bugtool.PLUGIN_DIR = dom0_template + "/etc/xensource/bugtool"
@@ -46,7 +52,7 @@ def test_load_plugins(bugtool, dom0_template):
         },
         "proc_version": {
             "cap": "mock",
-            "cmd_args": "cat /proc/version",
+            "cmd_args": "/usr/sbin/cat /proc/version",
             "filter": None,
         },
     }

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -121,7 +121,7 @@ def assert_minimal_bugtool(bugtool, state_archive, dom0_template, cap):
 
     # When debug output from ProcOutput is enabled, "Starting" is printed:
     if bugtool.ProcOutput.debug:
-        version = "cat /proc/version"
+        version = "/usr/sbin/cat /proc/version"
         etc_dir = "ls -l %s/etc" % dom0_template
         for msg in [version, etc_dir]:
             assert "[time.strftime]  Starting '%s'\n" % msg in captured_stdout

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -32,6 +32,22 @@
 # or func_output().
 #
 
+# Documentation on the Python type comments used in this project:
+#
+# The type comments use the syntax of PEP 484, PEP 526, and PEP 544.
+# For development, python 3.10+ is required and type comments are used
+# in order to not break compatibility with older Python versions. At runtime,
+# the type comments are ignored, so the code can still run on Python 2.7+,
+# although "Yangtze" has its own release branch now, so Python 2.7 support
+# can be dropped in future if we change the shebang to python3 to execute
+# xen-bugtool with Python 3 on XS 8.4 as well.
+# XS 8.4 is only compatible with Python 3.6, so while it supports type comments,
+# it only supports a subset of the latest type comment syntax.
+# Thus, type comments will still be used instead of inline type annotations.
+# This has the advantage that the type comments can use the latest syntax
+# and features, e.g. "str | None" instead of "Optional[str]" that would
+# require Python 3.10+ at runtime.
+
 # Special pylint disables for latest pylint on xen-bugtool itself (for the moment):
 # The old Pylint-1.9.x thinks some of these are useless:
 # pylint: disable=useless-suppression
@@ -557,8 +573,56 @@ def output(x):
 def output_ts(x):
     output("[%s]  %s" % (time.strftime("%x %X %Z"), x))
 
+def is_deemed_executable(command):
+    # type: (str | list[str]) -> bool
+    """Check if command is executable (supports absolute paths and it looks in $PATH)
+    :param command: The command to check, either a string or a list of strings.
+
+    Note: This function is also called from load_plugins(), feeding it a string
+    that contains arbitrary commands, shell builtins and even loops. An example
+    is `ls -lR /lib/modules/$(uname -r)/updates`. Such strings are not
+    validated here, and are only checked for being non-empty.
+    """
+    if not isinstance(command, list):
+        # We have a string, command is the string command or script to check
+        if command.startswith("/"):
+            # command starts with an absolute path, return if it is executable
+            return os.access(command.split()[0], os.X_OK)
+
+        # We cannot validate other strings, so check those just for non-emptiness:
+        # The load_plugins() function calls this function with arbitrary strings
+        # that may contain shell builtins, loops, etc. We cannot validate those,
+        # so we just check that the string is not empty or only whitespace.
+        return bool(command and command.strip())
+
+    # We have a list of command arguments, command[0] is the command to check
+    if command[0].startswith("/"):
+        return os.access(command[0], os.X_OK)
+
+    # command[0] was not an absolute path, look for the command in $PATH
+    for path_part in os.environ.get("PATH", "").split(":"):
+        # For xen-bugtool we only accept absolute paths here as we don't want
+        # to execute anything from the current directory (".") or relative paths
+        # in $PATH which would be a risk for the predictability of the command.
+        if path_part.startswith("/"):
+            if os.access(os.path.join(path_part, command[0]), os.X_OK):
+                return True
+    return False
+
 def cmd_output(cap, args, label = None, filter = None):
+    # type: (str, str | list[str], str | None, str | None) -> None
+    """Add a command output to the data dictionary to be collected
+    :param cap: The capability for which the command shall be executed.
+    :param args: The shell commands to run, either a string or a list of strings.
+    :param label: An optional label for the command output.
+    :param filter: An optional filter function to apply to the command output.
+
+    Note: This function is also called from load_plugins() which feeds it a string
+    that contains arbitrary commands, shell builtins and even for loops for /bin/sh.
+    """
     if cap in entries:
+        if not is_deemed_executable(args):
+            return
         if not label:
             if isinstance(args, list):
                 a = [aa for aa in args]


### PR DESCRIPTION
## cmd_output(): Check if the command is executable before planning to run it

The master branch is shared between XS8 and XS9. Recently, new `cmd_output()` calls were added for XS9, along with some commands that are no longer supported in XS9.

To avoid warnings about failing to execute commands at collection time, verify that the command is executable when compiling the list of commands to run, before executing all commands.

Last month, @MarkSymsCtx proposed this, and @rosslagerwall attempted to silence those warnings with more significant changes that would impact bugtool logging overall. That should be improved too, but it's a larger effort than just this targeted check to avoid those warnings specifically.

Most of the added lines are in the new unit test, test_cmd_output.py, to test all cases in the changed function. This ensures not only 100% code coverage but also that the function works exactly as expected, for both the existing code and the new executable check.

## Pull Request Overview

This PR adds executable validation to the `cmd_output()` function by introducing a new `is_deemed_executable()` helper function. The change prevents planning to run commands that are not actually executable, improving the robustness of the command execution logic.

- Introduced `is_deemed_executable()` function to validate command executability
- Modified `cmd_output()` to check executability before adding commands to the data dictionary
- Updated test files to use absolute paths for better test coverage

### Reviewed Changes

Copilot reviewed all changes in https://github.com/xenserver-next/status-report/pull/30 and finally only had minor 

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| xen-bugtool | Added `is_executable()` function and integrated executability check in `cmd_output()` |
| tests/unit/test_output.py | Updated test to use absolute path for cat command |
| tests/unit/test_load_plugins.py | Enhanced test documentation and updated to use absolute path |
| tests/integration/dom0-template/etc/xensource/bugtool/mock/stuff.xml | Updated mock configuration to use absolute path |
</details>

