### PR TITLE
pyproject.toml: Fix up the outdated maintainers list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,8 @@ authors = [
     {name = "Simon Rowe"},
 ]
 maintainers = [
-    {name = "Ashwin H"},
     {name = "Bernhard Kaindl"},
-    {name = "Pau Ruiz Safont"},
+    {name = "Mark Syms"},
     {name = "Ross Lagerwall"},
 ]
 readme = "README.md"


### PR DESCRIPTION
Fix the outdated maintainers list in `pyproject.toml`:
- Mark Syms became more active in caring about `xen-bugtool`, and contributes to it.
- Pau Ruiz Safont only helped to review PRs, but currently does not have review rights.
- Ashwin was re-assigned and no longer works with XenServer development

