### PR TITLE
.pre-commit-config.yaml: Update stages to fix the deprecation warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@
 # https://pre-commit.com/#automatically-enabling-pre-commit-on-repositories
 # All hooks: https://pre-commit.com/hooks.html
 fail_fast: false
-default_stages: [commit, push]
+default_stages: [pre-commit, pre-push]
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -89,7 +89,7 @@ repos:
         name: Ensure that changes staged for updating xen-bugtool are black-formatted
         files: xen-bugtool
         # If needed, hooks can be disabled temporarily by removing commit and push:
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
         entry: make
         pass_filenames: false
         args: [darker-xen-bugtool]


### PR DESCRIPTION
.pre-commit-config.yaml: Update stages to fix the deprecation warnings

Running `pre-commit` checks currently starts with these deprecation warnings:
```py
[WARNING] hook id `darker` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] top-level `default_stages` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```

Ran `pre-commit migrate-config` to update the config accordingly:
```diff
diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
index 4b9e468..be63b25 100644
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@
 # https://pre-commit.com/#automatically-enabling-pre-commit-on-repositories
 # All hooks: https://pre-commit.com/hooks.html
 fail_fast: false
-default_stages: [commit, push]
+default_stages: [pre-commit, pre-push]
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -89,7 +89,7 @@ repos:
         name: Ensure that changes staged for updating xen-bugtool are black-formatted
         files: xen-bugtool
         # If needed, hooks can be disabled temporarily by removing commit and push:
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
         entry: make
         pass_filenames: false
         args: [darker-xen-bugtool]

```