### PR TITLE
`tests/unit/test_xapidb_fiter.py`: Replace the `wlb_password` in `row` attributes of the `pool` table

### DIFF
--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -53,7 +53,7 @@ expected = r"""<?xml version="1.0" ?>
         <row NVRAM="(('EFI-variables'%.'REMOVED'))" id="1" snapshot_metadata="('NVRAM'%.'(('_%.'_')%.(\'EFI-variables\'%.\'REMOVED\')()"/>
     </table>
     <table name="pool">
-        <row ref="OpaqueRef:123" wlb_enabled="true" wlb_password="test_password"/>
+        <row ref="OpaqueRef:123" wlb_enabled="true" wlb_password="REMOVED"/>
     </table>
 </root>
 """

--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -27,6 +27,9 @@ original = r"""<?xml version="1.0" ?>
         snapshot_metadata="('NVRAM'%.'(('_%.'_')%.(\'EFI-variables\'%.\'data\')()">
         </row>
     </table>
+    <table name="pool">
+        <row ref="OpaqueRef:123" wlb_enabled="true" wlb_password="test_password"/>
+    </table>
 </root>
 """
 
@@ -48,6 +51,9 @@ expected = r"""<?xml version="1.0" ?>
     </table>
     <table name="VM">
         <row NVRAM="(('EFI-variables'%.'REMOVED'))" id="1" snapshot_metadata="('NVRAM'%.'(('_%.'_')%.(\'EFI-variables\'%.\'REMOVED\')()"/>
+    </table>
+    <table name="pool">
+        <row ref="OpaqueRef:123" wlb_enabled="true" wlb_password="test_password"/>
     </table>
 </root>
 """

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1524,8 +1524,14 @@ class XapiDBContentHandler(xml.sax.ContentHandler):
         s = re.sub(r"(?P<start>\'NVRAM\'\%\.\'\((\(\'[^\']+\%\.\'[^.]+\'\)\%\.)*\(\\\'EFI-variables\\\'\%\.\\\')[^\']+(?P<end>\\\')", r"\g<start>REMOVED\g<end>", metadata)
         attrs["snapshot_metadata"] = s
 
+    # Filter out wlb_password from the row entries of the pool table
+    def _filter_wlb_password(self, attrs):
+        if "wlb_password" in attrs:
+            attrs["wlb_password"] = self.STRIP_STR
+
     def _filter(self, attrs):
         table_filters = {
+            "pool": self._filter_wlb_password,
             "secret": self._filter_secret_table,
             "VM": self._filter_vm_table,
             "Cluster": self._filter_cluster_table


### PR DESCRIPTION
`xen-bugtool`, `tests/unit/test_xapidb_fiter.py`: Filter `wlb_password` in `row` attributes of the `pool` table

## Summary based on Sourcery review

Code:
- Add filtering values of the `wlb_password` attribute in the `row` entries of the `pool` table

Test:
- Extend the unit test to verify handling of the `wlb_password` attribute in `pool` table rows

## Pull Request Overview

### Commit 1:

Observe the `wlb_password` attribute being passed in rows of the `pool` table.

- Adds `pool` table entry with a `row` entry that has a `wlb_password` attribute.
- Demonstrates that the value of `wlb_password` is preserved during filtering operations.

### Commit 2:

Verify the filter:

- Adds filtering values of the `wlb_password` attribute in the `row` entries of the `pool` table
- Demonstrates that the value of `wlb_password` is removed during filtering operations.