### PR TITLE
`tests/unit/test_main.py`: Restore global variable after the temporary change to it.

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -291,16 +291,29 @@ def patched_bugtool(bugtool, mocker, dom0_template, tmp_path):
     """PyTest fixture providing a patched bugtool module with mocks and
     configurations to execute its main() from a unprivileged unit test process
     on a regular Linux host, with test data from the framework's dom0 template.
+    This fixture is function-scoped to avoid interference between test cases.
 
     :param bugtool: The imported bugtool module object to be patched.
     :param mocker: The mocker object for mocking functions and attributes.
     :param dom0_template: The path to the dom0 template directory.
     :param tmp_path: The temporary path for storing files.
     """
+
+    saved_db_conf = bugtool.DB_CONF  # Save the original DB_CONF to restore later
+
+    # Patch the bugtool module to be able to run its main() function as non-root
+    # user on a regular Linux host, using the dom0 template as source of files:
     patch_bugtool(bugtool, mocker, dom0_template, "main_mocked", tmp_path)
 
-    base_path = tmp_path / os.environ["XENRT_BUGTOOL_BASENAME"]
-    return bugtool, base_path.as_posix(), tmp_path.as_posix()
+    # For asserting the contents of the bugtool archive, its directory is needed:
+    archive_dir = tmp_path / os.environ["XENRT_BUGTOOL_BASENAME"]
+
+    # Yield to run the test case: Provide the patched bugtool module, the new
+    # function-scoped tmp path and the archive directory in it to the test case:
+    yield bugtool, archive_dir.as_posix(), tmp_path.as_posix()
+
+    # The test case is done (executed by yield). Restore the original DB_CONF:
+    bugtool.DB_CONF = saved_db_conf
 
 
 def test_main_func_output_to_zipfile(patched_bugtool, capfd):


### PR DESCRIPTION
Hi @GeraldEV, this PR improves a pytest fixture local to this test file:

Clean up a latent unit test problem in a pytest fixture for tests in this test file:

Problem:
- The pytest fixture used by tests in this file doesn't restore `bugtool.DB_CONF` after each test.

Fix this:
- Before running the test cases which use it, back up `bugtool.DB_CONF`
- After returning from the test cases, restore `bugtool.DB_CONF` from backup

I ran into the problem that this value was changed but not restored by this fixture when I wrote or updated a test case, so this PR is intended to avoid developers running into the same issue again.

It also
- improves the name of the local variable used to pass the directory they should expect the created archive tarball to the test cases from `base_path` to `archive_dir`: More specific, less generic.
- adds more comments to explain important details. For example, this fixture is function-scoped, so each test case using it is handled (wrapped) individually.