### PR TITLE
[`docs`] Describe bugtool operation and how bugtool plugins are defined and working

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,6 @@
         "sourcery.sourcery",
         "streetsidesoftware.code-spell-checker",
         "timonwong.shellcheck",
-        "valentjn.vscode-ltex",
+        "ltex-plus.vscode-ltex-plus",
     ]
 }

--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -118,6 +118,7 @@ ifaces
 inet
 init
 initialisation
+Initialise
 initialised
 initiatorname
 inotify

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -4,6 +4,13 @@ dictionaryDefinitions: []
 dictionaries:
   - .vscode/ltex.dictionary.en-US.txt
 words:
+  - bugtool
+  - corosync
+  - Initialise
   - ltex
+  - rrdd
+  - xapi
+  - xenserver
+  - xensource
 ignoreWords: []
 import: []

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -1,0 +1,124 @@
+# Operation of `xenserver-status-report`
+
+## High-Level Workflow Phases
+
+1. **Discovery**:
+
+   In the discovery phase, `xenserver-status-report` populates:
+
+   1. The global `caps` dictionary with the supported capabilities
+   2. The global `data` dictionary with the supported collection directives.
+
+      For each collection directive, depending on the directive type,
+      the `xenserver-status-report` function `load_plugins()` calls these
+      internal functions to define directives for collecting the requested data
+      for the capability provided by the plugin in the global `data` dictionary
+      of `xenserver-status-report`:
+
+      - `file_output()` to define a directive to collect a file for a capability
+      - `tree_output()` to define a directive to collect a tree for a capability
+      - `func_output()` to define a directive to run an internal function
+      - `cmd_output()` to define a directive to run an external command or a script
+
+      The keys are the filenames of the collected data, and the values are
+      dictionaries with the following keys:
+      - `cap`: The capability of the directive: one of the `CAP_` constants
+      - `path`: If created by `file_output`: The path to the file to collect
+      - `func`: If created by `func_output`: A function that returns the file data
+      - `cmd_args`: If created by `cmd_output`: The command to return the file data
+      - `filter`: An optional filter function to pass the file data through
+
+    The function `load_plugins()` also calls these functions to define the
+     capabilities and collection directives of the external bugtool plugins.
+
+2. **Selection**:
+   Plugins are enabled/disabled based on the `checked` and `hidden` attributes
+   and command line flags as well as `XEN_RT` environment variable.
+
+3. **Collection**:
+   The actions described in the `<collect>` section are performed.
+4. **Archiving**:
+   Collected data is archived in a `tar` or `zip` archive for submission.
+
+## Discovery Phase
+
+During the discovery phase, functions in `xenserver-status-report()`
+collect metadata about the data collection capabilities of xen-bugtool
+and its plugins.
+
+For the plugins, this discovery is done by `load_plugins()`:
+
+```mermaid
+flowchart TD
+  B@{ shape: docs,           label: "Scan the PLUGIN_DIR:
+                                     Get the plugin XML files"}
+  B --> C@{ shape: doc,      label: "For each plugin XML file:
+                                     Read the attributes of the
+                                     <tt>&lt;capability></tt> tag of
+                                     the main plugin XML."}
+  C --> D@{ shape: tag-doc,  label: "Add the capability attrs to the
+                                     list of available capabilities"}
+  D --> E@{ shape: win-pane, label: "Get the <tt>&lt;collect></tt> section
+                                     of each plugin's <tt>stuff.xml</tt>"}
+  E --> F@{ shape: diamond, label: "On each entry of
+                                    <tt>&lt;collect></tt>" }
+  F --> F1["Type &lt;files>:
+           Add pattern to the
+           <tt>data</tt> dictionary"]
+  F --> F2["Type &lt;list>:
+           Add pattern to the
+           <tt>data</tt> dictionary"]
+  F --> F3["Type &lt;directory>:
+            Add directory spec to the
+            <tt>data</tt> dictionary"]
+  F --> F4["Type &lt;command>:
+           Add command to the
+           <tt>data</tt> dictionary"]
+```
+
+## Selection phase
+
+In the selection phase, some or all discovered capabilities are selected
+for collection.
+
+## Collection Phase
+
+In the collection phase, `xenserver-status-report` traverses the internal `data`
+dictionary populated during the discovery phase for selected entries.
+
+It is implemented in the `collect_data()` function and the function it calls.
+
+The sub-phases are:
+
+1. Initialise the output archive.
+2. Run the commands of the selected capabilities and archive their output.
+   - Note: Some commands may create or update files to collect in the next steps
+3. Traverse the `<directory>` entries of the selected capabilities for files.
+4. Archive the files of the selected capabilities.
+
+### Flowchart of the Collection phase
+
+```mermaid
+flowchart TD
+  A1@{        shape: stadium,   label: "Initialise the
+                                        output archive"}
+  A1 --> A2@{ shape: docs,      label: "For all commands of the
+                                        selected capabilities
+                                        in the <tt>data</tt> dictionary"}
+  A2 --> B1@{ shape: processes, label: "Execute commands in parallel"}
+  A2 --> B2@{ shape: processes, label: "Execute commands in parallel"}
+  A2 --> B3@{ shape: processes, label: "Execute commands in parallel"}
+  B1 --> C1@{ shape: bow-rect,  label: "Add output to the archive until finished"}
+  B2 --> C2@{ shape: bow-rect,  label: "Add output to the archive until finished"}
+  B3 --> C3@{ shape: bow-rect,  label: "Add output to the archive until finished"}
+  C1 --> D@{  shape: hourglass, label: "Fork a process for each command to run"}
+  C2 --> D
+  C3 --> D
+  D  --> E["Traverse the
+            <tt>&lt;directory></tt> entries
+            of selected capabilities"]
+  E  --> F@{ shape: bow-rect,   label: "Add the data of the files
+                                        of the selected capabilities
+                                        to the output archive"}
+  F  --> H@{ shape: stadium,    label: "Close the archive"}
+```

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1,0 +1,107 @@
+# Plugins for `xen-bugtool` and overall operation
+
+The capabilities of `xen-bugtool` are extended by a number of plugins.
+
+Plugins are defined using XML files that describe what data to collect
+and how to collect it.
+
+This allows for flexible, declarative extension of `xen-bugtool`'s capabilities.
+
+## Top-level Plugin XML Structure
+
+Plugins are loaded by the `load_plugins()` function of `xenserver-status-report`.
+It looks in `PLUGIN_DIR` (`/etc/xensource/bugtool`) for XML files.
+
+For example, the `xapi` plugin is defined in `/etc/xensource/bugtool/xapi.xml`.
+
+Each plugin XML file uses a `<capability>` root element with several attributes:
+
+- **`pii`**: If the collected data may contain Personally Identifiable Information.
+  - Values: `no`, `yes`, `maybe`, or `if_customized`.
+- **`min_size` / `max_size`**:
+  - Values: Minimum and maximum expected size (in bytes) of the collected data.
+- **`min_time` / `max_time`**:
+  - Values: Minimum and maximum expected time (in seconds) to collect the data.
+- **`mime`**: The type of data collected.
+  - Values: `application/data` or `text/plain` (default).
+  - Included in the output of `--capabilities` as the `content-type` attribute
+    of the capability. No other use: Not included in the status-report itself.
+  - Currently, all currently known plugins use the default of `text/plain`.
+- **`checked`**: Whether this plugin is enabled by default.
+  - Values: `true` or `false`.
+- **`hidden`**: Whether this plugin is hidden from the user interface.
+  - Values: `true` or `false`.
+
+### Example `<capability>` Definition
+
+```xml
+<capability pii="yes" max_size="16384" max_time="4" checked="true"/>
+```
+
+Best practices:
+
+- Set `pii` to indicate if Personally Identifiable Information may be collected.
+- Set `max_size` and `max_time` according to the expected maximum size and time
+
+## Defining Data Collection in `/etc/xensource/bugtool/<plugin>/stuff.xml`
+
+The data collection directives are specified in another XML file.
+
+It is found in a subdirectory named after the plugin,
+e.g., `/etc/xensource/bugtool/xapi/stuff.xml`.
+
+It contains a single `<collect>` section which defines what data to gather.
+The possible subsections of the `<collect>` section are (each of these
+may occur multiple times):
+
+- **`<files>`**:
+  - Collect a file path, optionally using wildcards. Example:
+
+    ```xml
+    <files>/sys/fs/gfs2/*/uuid</files>
+    ```
+
+- **`<list recursive="true|false">`**:
+  - List the contents of specified directories.
+    If `recursive` is `true`, subdirectories are included. Example:
+
+    ```xml
+    <list>/var/lib/corosync</list>
+    ```
+
+- **`<directory pattern="regex" negate="true|false">basepath</directory>`**:
+  - Collect files in `basepath` matching the given `regex` pattern.
+    (Or not matching the pattern when `negate="true"`).
+    Example:
+
+    ```xml
+    <directory pattern=".*xcp-rrdd-plugins\.log.*">/var/log</directory>
+    ```
+
+- **`<command label="...">`**: Run the specified command and collect its output.
+  - The `label` attribute describes the output. Example:
+
+    ```xml
+    <command label="host_data_source_list">/opt/xensource/bin/xe host-data-source-list host=$(/opt/xensource/bin/xe pool-list params=master --minimal)</command>
+    ```
+
+### Example `stuff.xml` file from the `xapi` bugtool Plugin
+
+```xml
+<collect>
+<command label="sr_data_source_list">/opt/xensource/bin/xe sr-list --minimal | tr , '\n' | xargs --verbose -n 1 -I {} /opt/xensource/bin/xe sr-data-source-list uuid={} 2>&amp;1</command>
+<files>/etc/stunnel/xapi.conf</files>
+<list>/var/lib/corosync</list>
+<list recursive="false">/etc/xen/scripts</list>
+<directory pattern=".*\.log$" negate="false">/var/log/xen</directory>
+</collect>
+```
+
+In this example, `2>&amp;1` is the XML-escaped form of the shell redirection `2>&1`,
+which redirects `stderr` (file descriptor 2) to `stdout` (file descriptor 1).
+
+### Best Practices for plugin development
+
+- Use `pattern` and `negate` to fine-tune file selection.
+- Provide meaningful `label` values for commands.
+- Test plugins and ensure they perform within defined time and size limits.


### PR DESCRIPTION
While writing a bugtool plugin, I found that there was no documentation about bugtool plugins anywhere:
- Add `doc/plugins.md` as documentation on bugtool plugins and `doc/operation.md` on the collection process.

As rendered Markdown for review:
https://github.com/xenserver-next/status-report/blob/add-doc-plugins.md/doc/operation.md
https://github.com/xenserver-next/status-report/blob/add-doc-plugins.md/doc/plugins.md

Spelling has now been checked using Code Spell Checker and the LTeX documentation checker using Languagetool. Initial review and notices to clarify descriptions using GitHub Copilot.