### PR TITLE
CA-427358: Fix default value of readlines

### DIFF
--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1406,7 +1406,7 @@ def dump_xapi_subprocess_info(cap):
        Returns a string containing a pretty-printed pstree-like structure. """
     all_pids = [proc_entry for proc_entry in os.listdir("/proc") if proc_entry.isdigit()]
     def readlines(filename):
-        lines = ''
+        lines = []
         try:
             f = open(filename, "r")
             lines = f.readlines()


### PR DESCRIPTION
If readlines fails to open a file or read the contents, it will fail and return an empty string. However f.readlines (the exepcted output) produces a list of strings. This inconsistency causes some error handling code to treat the output as a populated list of strings instead of skipping over it (as the command failed).

Fix the issue by consistently returning the correct data type.